### PR TITLE
Lambda_QCD declarations to match JETSCAPE 3.6.1

### DIFF
--- a/src/jet/ISRRotation.cc
+++ b/src/jet/ISRRotation.cc
@@ -471,6 +471,7 @@ void ISRRotation::AddRemenant(Parton &Out,int label){
   int NHardScatterings = ini->pTHat.size();
   double Pz = (Rem.pz() >=0 ? 1.0:-1.0);
 
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
   Rem.reset_momentum(0.25 * Lambda_QCD, 0.25 * Lambda_QCD,Pz,0.0);
   Rem.set_color(Out.anti_color()); 
   Rem.set_anti_color(Out.color());

--- a/src/jet/ISRRotation.h
+++ b/src/jet/ISRRotation.h
@@ -62,6 +62,7 @@ class ISRRotation : public JetEnergyLossModule<ISRRotation>
     std::array<double, 2> pT; double LatestPartonNewPz;
     double s0 = 0.2, sP0;
     double TotalMomentumFraction;
+    double Lambda_QCD;
 
     std::string Fpath = "ISR-PT.dat";
     std::ofstream *File;

--- a/src/jet/iMATTER.cc
+++ b/src/jet/iMATTER.cc
@@ -1568,6 +1568,7 @@ double iMATTER::PDF(int pid, double z, double t){
 double iMATTER::alpha_s(double q2) {
   double a, L2, q24, c_nf;
 
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
   L2 = std::pow(Lambda_QCD, 2);
 
   q24 = q2 / 4.0;

--- a/src/jet/iMATTER.h
+++ b/src/jet/iMATTER.h
@@ -122,6 +122,7 @@ class iMATTER : public JetEnergyLossModule<iMATTER>
     int LabelOfTheShower, NPartonPerShower = 100000, MAX_COLOR;
     const double z_min_factor = 0.94; // this limits the parent momentum to be P_A/z_min_factor
     double TotalMomentumFraction, TotalMomentum;
+    double Lambda_QCD;
     
     Parton Parent,Sibling,Current;
     int Current_Status = 1e8, Current_Label = -1;


### PR DESCRIPTION
adds the changes made to the Lambda_QCD declarations in JETSCAPE 3.6.1 to additional classes specific to X-SCAPE.