### PR TITLE
applies Ritoban's pT-broadening fix from JETSCAPE

### DIFF
--- a/src/jet/LBT.cc
+++ b/src/jet/LBT.cc
@@ -191,6 +191,11 @@ void LBT::DoEnergyLoss(double deltaT, double time, double Q2,
       return;
     }
 
+    if (pIn[0].pstat()==101) {
+      // pOut.push_back(pIn[0]);
+       // JSINFO << BOLDYELLOW << " broadenend parton rejected by LBT ";
+        return;
+    }
     // pass particle infomation to LBT array (only pass one particle each time)
 
     jetClean();

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -1681,13 +1681,17 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
               energy -= drag;
               pOut[iout].reset_momentum(px, py, pz, energy);
             }
-
+            pOut[iout].set_stat(101);
             VERBOSE(8) << BOLDYELLOW << " p after b & d, E = " << energy
                        << " pz = " << pz << " px = " << px << " py = " << py;
           }
-
+          else{
+            pOut.push_back(pIn[i]);
+          }
         } // end if(broadening_on)
+        else{
           pOut.push_back(pIn[i]);
+        }
       }
     } else { // virtuality too low lets broaden it
 
@@ -1837,12 +1841,17 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
             energy -= drag;
             pOut[iout].reset_momentum(px, py, pz, energy);
           }
-
+          pOut[iout].set_stat(101);
           VERBOSE(8) << BOLDYELLOW << " p after b & d, E = " << energy
                      << " pz = " << pz << " px = " << px << " py = " << py;
         }
-
+        else{
+            pOut.push_back(pIn[i]);
+        }
         //pOut.push_back(pIn[i]);
+      }
+      else{
+        pOut.push_back(pIn[i]);
       }
     }
 


### PR DESCRIPTION
This PR applies Ritoban's pT-broadening fix from JETSCAPE 3.6.1.

"A new status code "101" is added to LBT.cc to tackle partons which has broadened. Now, energy loss module LBT doesn't push back such partons. The energy loss module Matter.cc has some extra logic condition in the broadening section, otherwise the same broadening parton was pushed in twice."