### PR TITLE
brings JETSCAPE 3.5.2 change to X-SCAPE

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -145,7 +145,6 @@
     <tStart> 0.6 </tStart> <!-- Start time of jet quenching, proper time, fm/c   -->
     <mutex>ON</mutex>
     <AddLiquefier> false </AddLiquefier>
-    <lambdaQCD>0.2</lambdaQCD> <!-- 0.4 is the value chosen in JETSET -->
 
     <Matter>
       <name>Matter</name>

--- a/src/framework/JetScapeConstants.h
+++ b/src/framework/JetScapeConstants.h
@@ -31,6 +31,9 @@ static double Ca = 3.0;
 
 static double Nc = 3.0;
 
+static double Lambda_QCD = 0.2;
+// 0.4 is the value chosen in JETSET
+
 static const double hbarC = 0.197327053;
 
 static const double fmToGeVinv = 1.0 / hbarC;

--- a/src/hadronization/ColorlessHadronization.cc
+++ b/src/hadronization/ColorlessHadronization.cc
@@ -110,8 +110,6 @@ void ColorlessHadronization::InitTask() {
     JSINFO << "Also reading in: " << s;
     pythia.readString(s);
   }
-  
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
 
   // Initialize random number distribution
   ZeroOneDistribution = std::uniform_real_distribution<double> { 0.0, 1.0 };

--- a/src/hadronization/ColorlessHadronization.h
+++ b/src/hadronization/ColorlessHadronization.h
@@ -37,7 +37,6 @@ public:
 private:
   double p_fake;
   bool take_recoil;
-  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<ColorlessHadronization> reg;

--- a/src/hydro/Brick.cc
+++ b/src/hydro/Brick.cc
@@ -82,7 +82,6 @@ void Brick::InitializeHydro(Parameter parameter_list) {
 
 void Brick::EvolveHydro() {
   VERBOSE(8);
-  VERBOSE(3) << "size of sd = " << ini->GetEntropyDensityDistribution().size();
   hydro_status = FINISHED;
 }
 

--- a/src/initialstate/epemGun.cc
+++ b/src/initialstate/epemGun.cc
@@ -140,8 +140,6 @@ void epemGun::InitTask() {
     throw std::runtime_error("Pythia init() failed.");
   }
 
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
-
   // Initialize random number distribution
   ZeroOneDistribution = uniform_real_distribution<double>{0.0, 1.0};
 

--- a/src/initialstate/epemGun.h
+++ b/src/initialstate/epemGun.h
@@ -31,7 +31,6 @@ private:
   //double pTHatMax;
   double eCM;
   //bool FSR_on;
-  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<epemGun> reg;

--- a/src/jet/ISRRotation.cc
+++ b/src/jet/ISRRotation.cc
@@ -471,7 +471,6 @@ void ISRRotation::AddRemenant(Parton &Out,int label){
   int NHardScatterings = ini->pTHat.size();
   double Pz = (Rem.pz() >=0 ? 1.0:-1.0);
 
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
   Rem.reset_momentum(0.25 * Lambda_QCD, 0.25 * Lambda_QCD,Pz,0.0);
   Rem.set_color(Out.anti_color()); 
   Rem.set_anti_color(Out.color());

--- a/src/jet/ISRRotation.h
+++ b/src/jet/ISRRotation.h
@@ -62,7 +62,6 @@ class ISRRotation : public JetEnergyLossModule<ISRRotation>
     std::array<double, 2> pT; double LatestPartonNewPz;
     double s0 = 0.2, sP0;
     double TotalMomentumFraction;
-    double Lambda_QCD;
 
     std::string Fpath = "ISR-PT.dat";
     std::ofstream *File;

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -142,7 +142,6 @@ void Matter::InitTask() {
   hydro_Tc = GetXMLElementDouble({"Eloss", "Matter", "hydro_Tc"});
   brick_length = GetXMLElementDouble({"Eloss", "Matter", "brick_length"});
   vir_factor = GetXMLElementDouble({"Eloss", "Matter", "vir_factor"});
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
 
   if (vir_factor < 0.0) {
     cout << "Reminder: negative vir_factor is set, initial energy will be used "

--- a/src/jet/Matter.h
+++ b/src/jet/Matter.h
@@ -107,7 +107,6 @@ public:
   double initR0, initRx, initRy, initRz, initVx, initVy, initVz, initRdotV,
       initVdotV, initEner;
   double Q00, Q0, T0;
-  double Lambda_QCD;
 
   static const int dimQhatTab = 151;
   double qhatTab1D[dimQhatTab] = {0.0};

--- a/src/jet/iMATTER.cc
+++ b/src/jet/iMATTER.cc
@@ -1568,7 +1568,6 @@ double iMATTER::PDF(int pid, double z, double t){
 double iMATTER::alpha_s(double q2) {
   double a, L2, q24, c_nf;
 
-  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
   L2 = std::pow(Lambda_QCD, 2);
 
   q24 = q2 / 4.0;

--- a/src/jet/iMATTER.h
+++ b/src/jet/iMATTER.h
@@ -122,8 +122,7 @@ class iMATTER : public JetEnergyLossModule<iMATTER>
     int LabelOfTheShower, NPartonPerShower = 100000, MAX_COLOR;
     const double z_min_factor = 0.94; // this limits the parent momentum to be P_A/z_min_factor
     double TotalMomentumFraction, TotalMomentum;
-    double Lambda_QCD;
-    
+
     Parton Parent,Sibling,Current;
     int Current_Status = 1e8, Current_Label = -1;
     FourVector RotationVector;


### PR DESCRIPTION
This PR brings JETSCAPE 3.6.2 change to X-SCAPE.

Reverts making Lambda_QCD an XML parameter, move back to JS constants,
Removes initial state pointer from Brick.cc
