### PR TITLE
Fixing logic related to broadening

### DIFF
--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -1844,13 +1844,7 @@ void Matter::DoEnergyLoss(double deltaT, double time, double Q2,
           VERBOSE(8) << BOLDYELLOW << " p after b & d, E = " << energy
                      << " pz = " << pz << " px = " << px << " py = " << py;
         }
-        else{
-            pOut.push_back(pIn[i]);
-        }
         //pOut.push_back(pIn[i]);
-      }
-      else{
-        pOut.push_back(pIn[i]);
       }
     }
 


### PR DESCRIPTION
This PR brings Ritoban's JETSCAPE 3.6.2 PR to X-SCAPE:

Fixing logic related to broadening. Now if a parton is not apt to split virtuality-wise, then the parton is pushed back only once if broadening is on+ recoil is off+qhat>0. Otherwise the parton in not pushed back. This is the same as it was in JETSCAPE-3.6.