### PR TITLE
Fix music wrapper bug

### DIFF
--- a/src/framework/PreequilibriumDynamics.cc
+++ b/src/framework/PreequilibriumDynamics.cc
@@ -52,6 +52,9 @@ void PreequilibriumDynamics::Init() {
            << "jetscape->Add(trento);";
   }
 
+  preequilibrium_tau_0_ = GetXMLElementDouble({"Preequilibrium", "tau0"});
+  preequilibrium_tau_max_ = GetXMLElementDouble({"Preequilibrium", "taus"});
+
   InitializePreequilibrium(parameter_list_);
 
   InitTask();

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -185,8 +185,6 @@ void MpiMusic::InitializeHydroEnergyProfile() {
   double dz = ini->GetZStep();
   double z_max = ini->GetZMax();
   int nz = ini->GetZSize();
-  double tau0 = pre_eq_ptr->GetPreequilibriumEndTime();
-  JSINFO << "hydro initial time  tau0 = " << tau0 << " fm"; //xyw
 
   // need further improvement to accept multiple source term objects
   music_hydro_ptr->generate_hydro_source_terms();
@@ -195,6 +193,8 @@ void MpiMusic::InitializeHydroEnergyProfile() {
     JSWARN << "Missing the pre-equilibrium module ...";
     music_hydro_ptr->initialize_hydro();
   } else {
+    double tau0 = pre_eq_ptr->GetPreequilibriumEndTime();
+    JSINFO << "hydro initial time  tau0 = " << tau0 << " fm";
     music_hydro_ptr->initialize_hydro_from_jetscape_preequilibrium_vectors(
         tau0,
         dx, dz, z_max, nz, pre_eq_ptr->e_, pre_eq_ptr->P_,


### PR DESCRIPTION
This moves the pre-equilibrium pointer in the MusicWrapper into the else case, where it is already checked to be properly initialized. This avoids segmentation faults.

I also implemented the initialization of the start and end time variables in the pre-equilibrium part of the code.
@chunshen1987 Is this correct? I took this from the Jetscape code. If I understood this correctly, it is needed in case no `NullPreDynamics` is used?