### PR TITLE
remove gtl binary_function & add macOS workflow

### DIFF
--- a/.github/workflows/plot_observables.yaml
+++ b/.github/workflows/plot_observables.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   PULL_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -31,7 +31,6 @@ jobs:
         export NONINTERACTIVE=1
         brew update
         brew cleanup
-        brew unlink pkg-config@0.29.2
         brew install --formula cmake
         brew install --formula doxygen
         brew install --formula root

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -1,0 +1,107 @@
+name: test build macOS native
+
+on:
+  pull_request:
+    branches:
+      - main
+      - XSCAPE-1.1.5-RC
+      - latessa/gtl_binary_function
+
+  push:
+    branches:
+      - main
+      - XSCAPE-1.1.5-RC
+      - latessa/gtl_binary_function
+
+env:
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  build:
+    name: install packages and build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14, macos-15]
+
+    steps:
+
+    - name: brew install dependencies
+      run: |
+        export NONINTERACTIVE=1
+        brew update
+        brew cleanup
+        brew unlink pkg-config@0.29.2
+        brew install --formula cmake
+        brew install --formula doxygen
+        brew install --formula root
+        brew install --formula graph-tool
+        brew install --formula hdf5
+        brew install --formula open-mpi
+        brew install --formula gsl
+        brew install --formula boost
+        brew install --formula zlib
+        . /opt/homebrew/bin/thisroot.sh
+    - name: set environment variables
+      run: |
+        export ROOTSYS="/usr/local/root"
+        export PATH="$ROOTSYS/bin:\$PATH"
+        export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
+        export PYTHONPATH="$ROOTSYS/lib"
+    - name: install HepMC 3.2.6
+      run: | # brew tap davidchall/hep
+        brew tap davidchall/homebrew-hep
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout f643d5cacc19fd0b01d0ecba0daf30452152da03
+        NONINTERACTIVE=1 brew install davidchall/hep/hepmc3
+    - name: install Pythia 8309
+      run: |
+        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
+        echo "Current directory: $(pwd)"
+        git checkout 141f8548d045df88d498ab44df16d2091742e4b1
+        NONINTERACTIVE=1 brew install davidchall/hep/pythia
+    - name: set more variables
+      run: |
+        export JETSCAPE_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}"
+    - name: Checkout JETSCAPE Repository
+      uses: actions/checkout@v4
+      with:
+        path: ${{ github.event.repository.name }}
+
+    - name: Download MUSIC
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_music.sh
+    - name: Download ISS
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_iSS.sh
+    - name: Download FREESTREAM
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_freestream-milne.sh
+    - name: Download SMASH
+      run: |
+        export PYTHIA8DIR="/opt/homebrew/opt/pythia"
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_smash.sh
+    - name: Download 3DGlauber
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_3dglauber.sh
+    - name: Build Application
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}
+        mkdir build
+        cd build
+        export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        echo "This is SMASH_DIR: "
+        echo ${SMASH_DIR}
+        ls ${SMASH_DIR}
+        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        make -j2
+    - name: Test Run
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build
+        ./runJetscape ../config/publications_config/arXiv_1910.05481/jetscape_user_PP_1910.05481.xml

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Dat.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Dat.yaml
@@ -6,12 +6,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Parton.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Parton.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
       - brick_matter_lbt
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
       - brick_matter_lbt
 
 env:

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -4,12 +4,12 @@ on:
   pull_request:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
   push:
     branches:
       - main
-      - XSCAPE-1.1.4-RC
+      - XSCAPE-1.1.5-RC
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# X-SCAPE 1.1.4
+# X-SCAPE 1.1.5
 
 The X-ion collisions with a Statistically and Computationally Advanced Program Envelope (X-SCAPE) is the enhanced (and 2nd) project of the JETSCAPE
 collaboration which extends the framework to include small systems created in p-A and p-p collisions, lower energy heavy-ion collisions and electron-Ion collisions.

--- a/external_packages/gtl/include/GTL/GTL.h
+++ b/external_packages/gtl/include/GTL/GTL.h
@@ -163,7 +163,6 @@ using std::stack;
 using std::map;
 using std::set;
 using std::allocator;
-using std::binary_function;
 using std::ostream;
 using std::ofstream;
 using std::cout;

--- a/external_packages/gtl/src/bid_dijkstra.cpp
+++ b/external_packages/gtl/src/bid_dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**

--- a/external_packages/gtl/src/dijkstra.cpp
+++ b/external_packages/gtl/src/dijkstra.cpp
@@ -30,7 +30,7 @@ __GTL_BEGIN_NAMESPACE
  * @internal
  * Binary predicate that compares two nodes according to their distance.
  */
-class less_dist : public binary_function<node, node, bool>
+class less_dist
 {
 public:
     /**


### PR DESCRIPTION
This PR resolves the compilation issue when using Clang 16 by removing the binary_function inheritance in the GTL library.

GitHub Actions workflows are also added to test that JETSCAPE compiles on native Mac hardware. Separate workflows use Clang 15 and Clang 16, so both compilers are verified.

This PR incorporates [JETSCAPE PR 234](https://github.com/JETSCAPE/JETSCAPE/pull/234)