### PR TITLE
PreEq fix

### DIFF
--- a/external_packages/get_iSS.sh
+++ b/external_packages/get_iSS.sh
@@ -18,7 +18,7 @@
 
 # using a commit from the iSS repository that is compatible with X-SCAPE 1.1.1
 folderName="iSS"
-commitHash="2471dcc0e74c4a2d86c08ae82ad4304643b30439"
+commitHash="db176d4cfaf804c9963f6927577d540f5f8be530"
 
 rm -fr iSS
 git clone https://github.com/chunshen1987/iSS -b JETSCAPE iSS


### PR DESCRIPTION
Fixing the runtime errors if the NullpreEquilibrium module is used. Update the iSS version to avoid nan or inf when the boost is too large.