### PR TITLE
update C++17 requirement CMakeLists syntax

### DIFF
--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
-      - latessa/gtl_binary_function
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -98,7 +98,7 @@ jobs:
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}
-        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DCMAKE_CXX_STANDARD=17
+        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
         make -j2
     - name: Test Run
       run: |

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Dat.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Dat.yaml
@@ -7,11 +7,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Parton.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Parton.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
       - brick_matter_lbt
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
       - brick_matter_lbt
 
 env:

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
+      - cpp17_cmake_syntax
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ endif (USE_SMASH)
 ### Compiler & Linker Flags ###
 ###############################
 message("Compiler and Linker flags ...")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall -std=c++17")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pipe -Wall")
 ## can turn off some warnings
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-reorder -Wno-unused-variable -Wno-inconsistent-missing-override -Wno-unused-private-field")
 ## Then set the build type specific options. These will be automatically appended.


### PR DESCRIPTION
This modernizes the CMakeLists syntax requiring C++17 so it will work on newer compilers.