### PR TITLE
Remove useHybridHad flag from xml

### DIFF
--- a/config/jetscape_user_MUSICMainClockTest.xml
+++ b/config/jetscape_user_MUSICMainClockTest.xml
@@ -31,7 +31,6 @@
       <PGun>
         <name>PGun</name>
         <pT>100</pT>
-        <useHybridHad>0</useHybridHad>
       </PGun>
   </Hard>
 

--- a/config/jetscape_user_iMATTERMCGlauberMUSIC.xml
+++ b/config/jetscape_user_iMATTERMCGlauberMUSIC.xml
@@ -74,7 +74,6 @@
     <Matter>
       <Q0> 2.0 </Q0>
       <in_vac> 1 </in_vac>
-      <useHybridHad>1</useHybridHad>
       <vir_factor> 0.25 </vir_factor>
       <recoil_on> 0 </recoil_on>
       <broadening_on> 0 </broadening_on>


### PR DESCRIPTION
There were still a few `useHybridHad` floating around in XS. They are now removed.