### PR TITLE
Add IP-Glasma to Build Test and Update README Instructions

### DIFF
--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
     
     steps:

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:
@@ -47,6 +49,11 @@ jobs:
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_freestream-milne.sh
 
+    - name: Download IPGLASMA
+      run: |
+        cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
+        ./get_ipglasma.sh
+
     - name: Download SMASH
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
@@ -63,5 +70,5 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
-        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGlasma=ON
         make -j2

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: main
+        ref: initialStageOrientation
         path: TEST-EXAMPLES
 
     - name: Run Pb-Pb tests

--- a/.github/workflows/test-events-Pythia-Isr-Dat.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Dat.yaml
@@ -8,12 +8,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -24,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-Pythia-Isr-Parton.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Parton.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -7,6 +7,7 @@ on:
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
       - brick_matter_lbt
+      - ipglasma
 
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
       - brick_matter_lbt
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -24,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -6,12 +6,14 @@ on:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
   push:
     branches:
       - main
       - XSCAPE-1.1.5-RC
       - cpp17_cmake_syntax
+      - ipglasma
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -22,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:stable
+      image: jetscape/base:v1.10
       options: --user root
 
     steps:

--- a/external_packages/README.md
+++ b/external_packages/README.md
@@ -138,34 +138,35 @@ To run JetScape test with SMASH:
 Currently the iSS sampler performs resonance decays after sampling.
 For reasonable physics with SMASH these decays should be switched off.
 
-### Installing and Compiling X-SCAPE with IP-Glasma
+## IP-Glasma
 
-The use of IP-Glasma with the current version of X-SCAPE is not fully integrated.  A workaround is provided here and applies to using the **jetscape/base:stable** Docker image.
+IP-Glasma requires the use of FFTW. The package `libfftw3-dev` is already included in JETSCAPE's supported [Docker image](https://hub.docker.com/r/jetscape/base).
 
-```
-cd ${JETSCAPE_DIR}/external_packages
+### Installing IP-Glasma
+
+To download IP-Glasma, one can run the shell script under the external_packages folder.
+
+```bash
 ./get_ipglasma.sh
 ```
-After the IP-Glasma package downloads, replace the file **${JETSCAPE_DIR}/external_packages/ipglasma/CMakeModules/FindFFTW.cmake** with this alternative FindFFTW.cmake found here:
 
-[Alternative FindFFTW.cmake File](https://git.jinr.ru/nica/bmnroot/-/blob/9fb98e26eb3e27fe379d3a61bad5d1567665bd81/cmake/modules/FindFFTW.cmake)
+This shell script will clone IP-Glasma to the external_packages folder.
 
-Then create a file called fftw3.h in the **${JETSCAPE_DIR}/external_packages/ipglasma/src** folder that includes the contents of the file linked here:
-
-[fftw3.h File](https://github.com/FFTW/fftw3/blob/master/api/fftw3.h)
+### Compiling JETSCAPE with IP-Glasma
 
 Create a build folder and cd into it.
+
 ```
 cd ${JETSCAPE_DIR}
 mkdir build
 cd build
 ```
 
-Include the fftw library paths as part of your cmake command:
+When compiling IP-Glasma with JETSCAPE, please turn on the IP-Glasma support option when generating the cmake configuration file.
 
-```
-cmake .. -DCMAKE_CXX_STANDARD=17 -DUSE_ROOT=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGlasma=ON -DFFTW_INCLUDE_DIR=/usr/lib/x86_64-linux-gnu/libfftw3.so.3.5.8 -DFFTW_LIBRARY=/usr/lib/x86_64-linux-gnu/libfftw3.so.3.5.8
+```bash
+cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON -DUSE_IPGlasma=ON
 
-make -j4     # Builds using 4 cores; adapt as appropriate
+make -j4  # Builds using 4 cores; adapt as appropriate
 ```
 If you're not compiling all the external modules, you don't have to turn them on.


### PR DESCRIPTION
This PR adds IP-Glasma to the external packages automated build test and updates the installation instructions in the external packages README.

I will change the Docker tag references in the test workflows from v1.10 to stable when the v1.10 image is tagged as stable for the release.