### PR TITLE
XML Lambda_QCD parameter

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -165,6 +165,7 @@
     <tStart> 0.6 </tStart> <!-- Start time of jet quenching, proper time, fm/c   -->
     <mutex>ON</mutex>
     <AddLiquefier> false </AddLiquefier>
+    <lambdaQCD>0.2</lambdaQCD> <!-- 0.2 JETSCAPE standard value, 0.4 is the value chosen in JETSET -->
 
     <Matter>
       <name>Matter</name>

--- a/src/framework/JetScapeConstants.h
+++ b/src/framework/JetScapeConstants.h
@@ -31,9 +31,6 @@ static double Ca = 3.0;
 
 static double Nc = 3.0;
 
-static double Lambda_QCD = 0.2;
-// 0.4 is the value chosen in JETSET
-
 static const double hbarC = 0.197327053;
 
 static const double fmToGeVinv = 1.0 / hbarC;

--- a/src/hadronization/ColorlessHadronization.cc
+++ b/src/hadronization/ColorlessHadronization.cc
@@ -111,6 +111,8 @@ void ColorlessHadronization::InitTask() {
     pythia.readString(s);
   }
 
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
+
   // Initialize random number distribution
   ZeroOneDistribution = std::uniform_real_distribution<double> { 0.0, 1.0 };
   // And initialize

--- a/src/hadronization/ColorlessHadronization.h
+++ b/src/hadronization/ColorlessHadronization.h
@@ -37,6 +37,7 @@ public:
 private:
   double p_fake;
   bool take_recoil;
+  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<ColorlessHadronization> reg;

--- a/src/initialstate/epemGun.cc
+++ b/src/initialstate/epemGun.cc
@@ -140,6 +140,8 @@ void epemGun::InitTask() {
     throw std::runtime_error("Pythia init() failed.");
   }
 
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
+
   // Initialize random number distribution
   ZeroOneDistribution = uniform_real_distribution<double>{0.0, 1.0};
 

--- a/src/initialstate/epemGun.h
+++ b/src/initialstate/epemGun.h
@@ -31,6 +31,7 @@ private:
   //double pTHatMax;
   double eCM;
   //bool FSR_on;
+  double Lambda_QCD;
 
   // Allows the registration of the module so that it is available to be used by the Jetscape framework.
   static RegisterJetScapeModule<epemGun> reg;

--- a/src/jet/ISRRotation.cc
+++ b/src/jet/ISRRotation.cc
@@ -67,7 +67,8 @@ void ISRRotation::InitTask()
   JSINFO<<"Intialize ISRRotation ...";
 
   P_A = GetXMLElementDouble({"Hard","PythiaGun","eCM"})/2.0;  /// Assuming symmetric system
-  
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
+
   P_B = P_A ; /// assuming symmetric system, rewrite for non-symmetric collision.
 
   if (!P_A)

--- a/src/jet/ISRRotation.h
+++ b/src/jet/ISRRotation.h
@@ -62,6 +62,7 @@ class ISRRotation : public JetEnergyLossModule<ISRRotation>
     std::array<double, 2> pT; double LatestPartonNewPz;
     double s0 = 0.2, sP0;
     double TotalMomentumFraction;
+    double Lambda_QCD;
 
     std::string Fpath = "ISR-PT.dat";
     std::ofstream *File;

--- a/src/jet/Matter.cc
+++ b/src/jet/Matter.cc
@@ -144,6 +144,7 @@ void Matter::InitTask() {
   brick_length = GetXMLElementDouble({"Eloss", "Matter", "brick_length"});
   vir_factor = GetXMLElementDouble({"Eloss", "Matter", "vir_factor"});
   initial_virtuality_pT = GetXMLElementInt({"Eloss", "Matter", "initial_virtuality_pT"});
+  Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
 
   if(vir_factor < 0.0) {
     JSWARN << "vir_factor should not be negative";

--- a/src/jet/Matter.h
+++ b/src/jet/Matter.h
@@ -108,6 +108,7 @@ public:
   double initR0, initRx, initRy, initRz, initVx, initVy, initVz, initRdotV,
       initVdotV, initEner;
   double Q00, Q0, T0;
+  double Lambda_QCD;
 
   static const int dimQhatTab = 151;
   double qhatTab1D[dimQhatTab] = {0.0};

--- a/src/jet/iMATTER.cc
+++ b/src/jet/iMATTER.cc
@@ -72,6 +72,7 @@ void iMATTER::InitTask()
     // alpha_s = 0.2;
     Q0 = GetXMLElementDouble({"Eloss", "Matter", "Q0"});
     vir_factor = GetXMLElementDouble({"Eloss", "Matter", "vir_factor"});
+    Lambda_QCD = GetXMLElementDouble({"Eloss","lambdaQCD"});
 
     RealP_A = GetXMLElementDouble({"Hard","PythiaGun","eCM"})/2.0;  /// Assuming symmetric system
     

--- a/src/jet/iMATTER.h
+++ b/src/jet/iMATTER.h
@@ -41,6 +41,7 @@ class iMATTER : public JetEnergyLossModule<iMATTER>
    virtual ~iMATTER();
 
    double Q0;
+   double Lambda_QCD;
 
    void InitTask();
    void DoEnergyLoss(double deltaT,double time, double Q2, vector<Parton>& pIn, vector<Parton>& pOut);


### PR DESCRIPTION
This adds the `Lambda_QCD` as XML parameter.

@cparker24 Should we also add the `Qs` to the XML? I forgot to mention this in the meeting this morning.