### PR TITLE
Write more info in the Qn vector output file

### DIFF
--- a/src/framework/JetScapeWriterQnCalculator.h
+++ b/src/framework/JetScapeWriterQnCalculator.h
@@ -67,6 +67,7 @@ public:
 protected:
   T output_file; //!< Output file
   std::vector<std::shared_ptr<Hadron>> particles;
+  bool writeCentrality;
   static RegisterJetScapeModule<JetScapeWriterQnVectorStream<ofstream>> regQnVector;
   static RegisterJetScapeModule<JetScapeWriterQnVectorStream<ogzstream>> regQnVectorGZ;
 private:
@@ -78,8 +79,6 @@ private:
   int nrap_;
   int norder_;
   std::map< int, int > chpdg_;
-
-
 };
 
 


### PR DESCRIPTION
This PR brings changes from JETSCAPE PR 277 to X-SCAPE.

Write more info in the Qn vector output file. (https://github.com/JETSCAPE/JETSCAPE/issues/276, https://github.com/JETSCAPE/JETSCAPE/pull/277)