### PR TITLE
Require cmake 3 5

### DIFF
--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -35,7 +37,6 @@ jobs:
         export NONINTERACTIVE=1
         brew update
         brew cleanup
-        brew install --formula cmake
         brew install --formula doxygen
         brew install --formula root
         brew install --formula graph-tool
@@ -44,29 +45,86 @@ jobs:
         brew install --formula gsl
         brew install --formula boost
         brew install --formula zlib
+        brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
+
     - name: set environment variables
       run: |
         export ROOTSYS="/usr/local/root"
         export PATH="$ROOTSYS/bin:\$PATH"
         export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
         export PYTHONPATH="$ROOTSYS/lib"
-    - name: install HepMC 3.2.6
-      run: | # brew tap davidchall/hep
-        brew tap davidchall/homebrew-hep
-        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
-        echo "Current directory: $(pwd)"
-        git checkout f643d5cacc19fd0b01d0ecba0daf30452152da03
-        NONINTERACTIVE=1 brew install davidchall/hep/hepmc3
-    - name: install Pythia 8309
+
+    - name: Download CMake 3.31.6
       run: |
-        cd $(brew --repository)/Library/Taps/davidchall/homebrew-hep
-        echo "Current directory: $(pwd)"
-        git checkout 141f8548d045df88d498ab44df16d2091742e4b1
-        NONINTERACTIVE=1 brew install davidchall/hep/pythia
+        curl -L -o cmake.dmg https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-macos-universal.dmg
+
+    - name: Mount CMake disk image
+      run: |
+        hdiutil attach cmake.dmg -mountpoint /Volumes/CMake
+
+    - name: Copy CMake.app to home directory
+      run: |
+        mkdir -p $HOME/cmake
+        cp -R /Volumes/CMake/CMake.app $HOME/cmake/
+
+    - name: Unmount CMake disk image
+      run: |
+        hdiutil detach /Volumes/CMake
+
+    - name: Add CMake to PATH
+      run: echo "$HOME/cmake/CMake.app/Contents/bin" >> $GITHUB_PATH
+
+    - name: Verify CMake version
+      run: cmake --version
+
+
+    - name: Download HepMC 3.2.6
+      run: |
+        curl -L -O http://hepmc.web.cern.ch/hepmc/releases/HepMC3-3.2.6.tar.gz
+        ls -l
+
+    - name: Build and Install HepMC 3.2.6
+      run: |
+        tar -xzf HepMC3-3.2.6.tar.gz
+        ls -l
+        cp -r HepMC3-3.2.6 hepmc3-source
+        mkdir hepmc3-build
+        cd hepmc3-build
+        cmake -DCMAKE_INSTALL_PREFIX=../hepmc3-install   \
+          -DHEPMC3_ENABLE_ROOTIO:BOOL=OFF            \
+          -DHEPMC3_ENABLE_PROTOBUFIO:BOOL=OFF        \
+          -DHEPMC3_ENABLE_TEST:BOOL=OFF              \
+          -DHEPMC3_INSTALL_INTERFACES:BOOL=ON        \
+          -DHEPMC3_BUILD_STATIC_LIBS:BOOL=OFF        \
+          -DHEPMC3_BUILD_DOCS:BOOL=OFF               \
+          -DHEPMC3_ENABLE_PYTHON:BOOL=ON             \
+          -DHEPMC3_PYTHON_VERSIONS=3.12              \
+          -DHEPMC3_Python_SITEARCH312=../hepmc3-install/lib/python3.12/site-packages \
+          ../hepmc3-source
+        make
+        make install
+
+    - name: Download Pythia 8309
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        curl -SLOk http://pythia.org/download/pythia83/pythia8309.tgz
+        ls -l
+
+    - name: Build and Install Pythia 8309
+      run: |
+        tar -xzf pythia8309.tgz
+        ls -l
+        cd pythia8309
+        ./configure --enable-shared --prefix=${GITHUB_WORKSPACE}/pythia8309 --with-hepmc3=${GITHUB_WORKSPACE}/hepmc3-install
+        make
+        make install
+
     - name: set more variables
       run: |
-        export JETSCAPE_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}"
+        echo "JETSCAPE_DIR=${GITHUB_WORKSPACE}/${REPO_NAME}" >> $GITHUB_ENV
+        echo "PYTHIA8DIR=${GITHUB_WORKSPACE}/pythia8309" >> $GITHUB_ENV
+
     - name: Checkout JETSCAPE Repository
       uses: actions/checkout@v4
       with:
@@ -76,23 +134,29 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_music.sh
+
     - name: Download ISS
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_iSS.sh
+
     - name: Download FREESTREAM
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_freestream-milne.sh
+
     - name: Download SMASH
       run: |
-        export PYTHIA8DIR="/opt/homebrew/opt/pythia"
+        echo "JETSCAPE_DIR is $JETSCAPE_DIR"
+        echo "PYTHIA8DIR is $PYTHIA8DIR"
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_smash.sh
+
     - name: Download 3DGlauber
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
         ./get_3dglauber.sh
+
     - name: Build Application
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}
@@ -104,6 +168,7 @@ jobs:
         ls ${SMASH_DIR}
         cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
         make -j2
+
     - name: Test Run
       run: |
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/build

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Dat.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Dat.yaml
@@ -10,6 +10,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Parton.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Parton.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -9,6 +9,7 @@ on:
       - brick_matter_lbt
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -18,6 +19,7 @@ on:
       - brick_matter_lbt
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -8,6 +8,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - cpp17_cmake_syntax
       - ipglasma
       - support_LHAPDF
+      - require_cmake_3_5
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ### Initial Cmake Setup ###
 ###########################
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (JetScape CXX C)
 
 # Fail if cmake is called in the source directory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project (libJetScape)
 
 #for MacOSX


### PR DESCRIPTION
This PR updates X-SCAPE's CMakeLists minimum version required parameter to 3.5 from 3.0, as the new cmake 4.0 requires projects built using cmake to require cmake 3.5 as a minimum.

Also, the GitHub Actions workflow that builds and tests a native MacOS installation has been updated to install cmake, Pythia 8.309, and HepMC3 3.2.6 from source instead of from Homebrew or Homebrew taps. This resolves the issue where checking out older brew commits to get these specific older versions of Pythia and HepMC3 failed on account of the new cmake minimum requirement.