### PR TITLE
Binary writer

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -30,6 +30,8 @@
   <JetScapeWriterRootHepMC> off </JetScapeWriterRootHepMC>
   <JetScapeWriterFinalStatePartonsAscii> off </JetScapeWriterFinalStatePartonsAscii>
   <JetScapeWriterFinalStateHadronsAscii> off </JetScapeWriterFinalStateHadronsAscii>
+  <!--Final state hadron/parton output in binary mode, only ascii or only binary switch (not both possible at the same time)-->
+  <binary_output> 0 </binary_output>
   <JetScapeWriterQnVectorAscii>off</JetScapeWriterQnVectorAscii>
   <QnVector_pTmin>0</QnVector_pTmin>
   <QnVector_pTmax>6</QnVector_pTmax>

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -30,8 +30,6 @@
   <JetScapeWriterRootHepMC> off </JetScapeWriterRootHepMC>
   <JetScapeWriterFinalStatePartonsAscii> off </JetScapeWriterFinalStatePartonsAscii>
   <JetScapeWriterFinalStateHadronsAscii> off </JetScapeWriterFinalStateHadronsAscii>
-  <!--Final state hadron/parton output in binary mode, only ascii or only binary switch (not both possible at the same time)-->
-  <binary_output> 0 </binary_output>
   <JetScapeWriterQnVectorAscii>off</JetScapeWriterQnVectorAscii>
   <QnVector_pTmin>0</QnVector_pTmin>
   <QnVector_pTmax>6</QnVector_pTmax>
@@ -54,6 +52,8 @@
        <statusToSkip>-9999</statusToSkip>
        <headerVersion>2</headerVersion>
     </FinalStatePartons>
+    <!--JetScapeWriterFinalStateHadronsAscii/JetScapeWriterFinalStatePartonsAscii output in binary mode, only ascii or only binary switch (not both possible at the same time)-->
+    <JetscapeWriterFinalStateBinaryOutput> 0 </JetscapeWriterFinalStateBinaryOutput>
   </Writer>
 
   <!--  Random Settings. For now, just a global  seed. -->

--- a/examples/convert_binary_to_ASCII_output.py
+++ b/examples/convert_binary_to_ASCII_output.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Binary to ASCII Converter for JETSCAPE Final State Files
+
+This script reads a binary file containing event data in a specific format and writes
+an ASCII representation of the data to a specified output file. It supports both
+parton and hadron final states and is suitable for large files through buffered streaming.
+
+Usage:
+    python convert_binary_to_ascii.py input_file output_file partons/hadrons
+
+Author: Hendrik Roch
+"""
+
+import argparse
+import struct
+
+
+def convert_binary_to_ASCII(
+    binary_file_path, ascii_file_path, parton_or_hadron
+):
+    """
+    Convert a binary final state file to ASCII format.
+
+    Parameters
+    ----------
+    binary_file_path : str
+        Path to the binary file.
+    ascii_file_path : str
+        Output path for the ASCII file.
+    parton_or_hadron : str
+        Either 'partons' or 'hadrons' indicating the final state type.
+
+    Raises
+    ------
+    ValueError
+        If the file is too short or malformed.
+    """
+    with open(binary_file_path, "rb") as bin_f, open(
+        ascii_file_path, "w", buffering=1024 * 1024
+    ) as out_f:
+        # --- HEADER ---
+        raw = bin_f.read(20)
+        if len(raw) < 20:
+            raise ValueError("File too short to contain valid header.")
+
+        file_version, *status_codes = struct.unpack("5i", raw)
+        out_f.write(
+            f"JETSCAPE_FINAL_STATE\tv{file_version}\t|\tN\tpid\tstatus\tE\tPx\tPy\tPz\n"
+        )
+        # Skipped status codes are not written to the output file, write only message to terminal
+        # Only print if status codes are different from 666
+        for code in status_codes:
+            if code != 666:
+                print(f"Status code {code} was filtered out in original file.")
+
+        # --- Events ---
+        bin_f.seek(0, 2)
+        file_size = bin_f.tell()
+        FOOTER_SIZE = 16  # two doubles
+        bin_f.seek(20)  # After header
+        offset = 20
+
+        while offset < file_size - FOOTER_SIZE:
+            bin_f.seek(offset)
+            header = bin_f.read(36)
+            if len(header) < 36:
+                raise ValueError(
+                    f"Unexpected EOF reading event header at offset {offset}"
+                )
+
+            (event_number,) = struct.unpack_from("i", header, 0)
+            (event_weight,) = struct.unpack_from("d", header, 4)
+            event_plane_angle, vx, vy, vz, centrality, pt_hat = (
+                struct.unpack_from("6f", header, 12)
+            )
+
+            offset += 36
+            bin_f.seek(offset)
+            raw = bin_f.read(4)
+            if len(raw) < 4:
+                raise ValueError(
+                    f"Unexpected EOF reading particle count at offset {offset}"
+                )
+            (num_particles,) = struct.unpack("i", raw)
+            offset += 4
+
+            particle_data_size = 24 * num_particles
+            bin_f.seek(offset)
+            particle_data = bin_f.read(particle_data_size)
+            if len(particle_data) < particle_data_size:
+                raise ValueError(
+                    f"Unexpected EOF reading {num_particles} particles at offset {offset}"
+                )
+            offset += particle_data_size
+
+            out_f.write(
+                f"#\tEvent\t{event_number}\t"
+                f"weight\t{event_weight:.15f}\t"
+                f"EPangle\t{event_plane_angle:.6f}\t"
+                f"N_{parton_or_hadron}\t{num_particles}\t"
+                f"vertex_x\t{vx:.6f}\tvertex_y\t{vy:.6f}\tvertex_z\t{vz:.6f}\t"
+                f"centrality\t{centrality:.6f}\tpt_hat\t{pt_hat:.6f}\n"
+            )
+
+            for i in range(num_particles):
+                base = i * 24
+                pid, status = struct.unpack_from("2i", particle_data, base)
+                e, px, py, pz = struct.unpack_from(
+                    "4f", particle_data, base + 8
+                )
+                out_f.write(
+                    f"{i} {pid} {status} "
+                    f"{e:.6f} {px:.6f} {py:.6f} {pz:.6f}\n"
+                )
+
+        # --- Footer ---
+        bin_f.seek(offset)
+        footer = bin_f.read(16)
+        if len(footer) != 16:
+            raise ValueError("Unexpected EOF reading footer.")
+        sigmaGen, sigmaErr = struct.unpack("2d", footer)
+        out_f.write(f"#\tsigmaGen\t{sigmaGen:.6e}\tsigmaErr\t{sigmaErr:.6e}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert a JETSCAPE binary final state file to ASCII format."
+    )
+    parser.add_argument(
+        "binary_file_path", type=str, help="Path to the binary file to convert."
+    )
+    parser.add_argument(
+        "ascii_file_path",
+        type=str,
+        help="Path to save the converted ASCII file.",
+    )
+    parser.add_argument(
+        "parton_or_hadron",
+        type=str,
+        choices=["partons", "hadrons"],
+        help="Specify 'partons' or 'hadrons' for the conversion.",
+    )
+    args = parser.parse_args()
+    # Call the function to convert the binary file to ASCII
+    convert_binary_to_ASCII(
+        args.binary_file_path, args.ascii_file_path, args.parton_or_hadron
+    )
+    # Print a message indicating the conversion is complete
+    print(
+        f"Conversion complete. The ASCII file is saved at {args.ascii_file_path}."
+    )

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -149,7 +149,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
     output_file << ss.str();
   } else {
     const int event_number = GetCurrentEvent() + 1;
-    const float event_weight = static_cast<float>(GetHeader().GetEventWeight());
+    const double event_weight = static_cast<double>(GetHeader().GetEventWeight());
     const float event_plane_angle = static_cast<float>(GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0);
     const float vertex_x = static_cast<float>(GetHeader().GetVertexX());
     const float vertex_y = static_cast<float>(GetHeader().GetVertexY());
@@ -159,7 +159,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
 
     // Write the event number, weight, and event plane angle, ...
     output_file.write(reinterpret_cast<const char*>(&event_number), sizeof(int));
-    output_file.write(reinterpret_cast<const char*>(&event_weight), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&event_weight), sizeof(double));
     output_file.write(reinterpret_cast<const char*>(&event_plane_angle), sizeof(float));
     output_file.write(reinterpret_cast<const char*>(&vertex_x), sizeof(float));
     output_file.write(reinterpret_cast<const char*>(&vertex_y), sizeof(float));
@@ -338,10 +338,10 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
         << "sigmaErr\t" << GetHeader().GetSigmaErr() << "\n";
   } else {
     // Write xsec output at the end.
-    const float sigmaGen = static_cast<float>(GetHeader().GetSigmaGen());
-    output_file.write(reinterpret_cast<const char*>(&sigmaGen), sizeof(float));
-    const float sigmaErr = static_cast<float>(GetHeader().GetSigmaErr());
-    output_file.write(reinterpret_cast<const char*>(&sigmaErr), sizeof(float));
+    const double sigmaGen = static_cast<double>(GetHeader().GetSigmaGen());
+    output_file.write(reinterpret_cast<const char*>(&sigmaGen), sizeof(double));
+    const double sigmaErr = static_cast<double>(GetHeader().GetSigmaErr());
+    output_file.write(reinterpret_cast<const char*>(&sigmaErr), sizeof(double));
   }
   output_file.close();
 }

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -66,7 +66,8 @@ JetScapeWriterFinalStateStream<T>::JetScapeWriterFinalStateStream(string m_file_
   writePtHat{false},
   particleStatusToSkip{},
   output_file{},
-  headerVersion{2}
+  headerVersion{2},
+  binaryOutput{false}
 {
   SetOutputFileName(m_file_name_out);
 }
@@ -79,74 +80,133 @@ template <class T> JetScapeWriterFinalStateStream<T>::~JetScapeWriterFinalStateS
 
 template <class T> void JetScapeWriterFinalStateStream<T>::WriteEvent() {
   // Write the entire event all at once.
-
-  // Optionally write event centrality to event header
-  std::string centrality_text = "";
-  if (writeCentrality) {
-    centrality_text += "\tcentrality\t";
-    centrality_text += std::to_string(GetHeader().GetEventCentrality());
-  }
-
-  // Optionally write pt-hat value to event header
-  std::string pt_hat_text = "";
-  if (writePtHat) {
-    pt_hat_text += "\tpt_hat\t";
-    pt_hat_text += std::to_string(GetHeader().GetPtHat());
-  }
-
-  // We cannot write directly to the file since we don't know how many particles we have in the filtered case.
-  // To resolve this, we'll write to an intermediate stringstream, and then write that to file.
-  std::stringstream ss;
-
-  // Next, write the particles. Will contain either hadrons or partons based on the derived class.
-  unsigned int ipart = 0;
-  for (const auto & p : particles) {
-
-    auto particle = p.get();
-    // Skip particles with requested status codes (if enabled).
-    if (particleStatusToSkip.size() > 0) {
-      // Skip particles with status codes that are in the list to skip
-      if (std::find(particleStatusToSkip.begin(), particleStatusToSkip.end(), particle->pstat()) != particleStatusToSkip.end()) {
-        continue;
+  if (!binaryOutput) {
+    // Optionally write event centrality to event header
+    std::string centrality_text = "";
+    if (writeCentrality) {
+      centrality_text += "\tcentrality\t";
+      centrality_text += std::to_string(GetHeader().GetEventCentrality());
+    }
+  
+    // Optionally write pt-hat value to event header
+    std::string pt_hat_text = "";
+    if (writePtHat) {
+      pt_hat_text += "\tpt_hat\t";
+      pt_hat_text += std::to_string(GetHeader().GetPtHat());
+    }
+  
+    // We cannot write directly to the file since we don't know how many particles we have in the filtered case.
+    // To resolve this, we'll write to an intermediate stringstream, and then write that to file.
+    std::stringstream ss;
+  
+    // Next, write the particles. Will contain either hadrons or partons based on the derived class.
+    unsigned int ipart = 0;
+    for (const auto & p : particles) {
+  
+      auto particle = p.get();
+      // Skip particles with requested status codes (if enabled).
+      if (particleStatusToSkip.size() > 0) {
+        // Skip particles with status codes that are in the list to skip
+        if (std::find(particleStatusToSkip.begin(), particleStatusToSkip.end(), particle->pstat()) != particleStatusToSkip.end()) {
+          continue;
+        }
       }
+  
+      ss  << ipart
+          // << " " << particle->plabel()
+          << " " << particle->pid()
+          << " " << particle->pstat()
+          << " " << particle->e()
+          << " " << particle->px()
+          << " " << particle->py()
+          << " " << particle->pz()
+          << "\n";
+      ++ipart;
+    }
+  
+    // Now that we've filtered the particles, we can finally write to the output file.
+    // First, write header
+    // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
+    // NOTE: Could also add Npart, Ncoll, and TotalEntropy. See the original stream writer.
+    // NOTE: ipart == total number of (filtered) particles by the end of the loop, so we can just take advantage of it.
+    output_file << "#"
+        << "\t" << "Event\t" << GetCurrentEvent() + 1  // +1 to index the event count from 1
+        << "\t" << "weight\t" << std::setprecision(15) << GetHeader().GetEventWeight() << std::setprecision(6)
+        << "\t" << "EPangle\t" << (GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0)
+        << "\t" << "N_" << GetName() << "\t" << ipart;
+    if (headerVersion == 3) {
+      output_file
+          << "\t" << "vertex_x\t" << GetHeader().GetVertexX()
+          << "\t" << "vertex_y\t" << GetHeader().GetVertexY()
+          << "\t" << "vertex_z\t" << GetHeader().GetVertexZ();
+    }
+    output_file
+        << centrality_text
+        << pt_hat_text
+        <<  "\n";
+  
+    // Finally, write the particles
+    output_file << ss.str();
+  } else {
+    const int event_number = GetCurrentEvent() + 1;
+    const float event_weight = static_cast<float>(GetHeader().GetEventWeight());
+    const float event_plane_angle = static_cast<float>(GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0);
+    const float vertex_x = static_cast<float>(GetHeader().GetVertexX());
+    const float vertex_y = static_cast<float>(GetHeader().GetVertexY());
+    const float vertex_z = static_cast<float>(GetHeader().GetVertexZ());
+    const float centrality = static_cast<float>(GetHeader().GetEventCentrality());
+    const float pt_hat = static_cast<float>(GetHeader().GetPtHat());
+
+    // Write the event number, weight, and event plane angle, ...
+    output_file.write(reinterpret_cast<const char*>(&event_number), sizeof(int));
+    output_file.write(reinterpret_cast<const char*>(&event_weight), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&event_plane_angle), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&vertex_x), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&vertex_y), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&vertex_z), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&centrality), sizeof(float));
+    output_file.write(reinterpret_cast<const char*>(&pt_hat), sizeof(float));
+
+    // Create a vector of int to store the pid, pstat values
+    std::vector<int> pid_values;
+    std::vector<int> pstat_values;
+    // Create a vector of float to store the e, px, py, pz values
+    std::vector<float> e_values;
+    std::vector<float> px_values;
+    std::vector<float> py_values;
+    std::vector<float> pz_values;
+    for (const auto & p : particles) {
+      auto particle = p.get();
+      // Skip particles with requested status codes (if enabled).
+      if (particleStatusToSkip.size() > 0) {
+        // Skip particles with status codes that are in the list to skip
+        if (std::find(particleStatusToSkip.begin(), particleStatusToSkip.end(), particle->pstat()) != particleStatusToSkip.end()) {
+          continue;
+        }
+      }
+
+      // Store the values in the vectors
+      pid_values.push_back(particle->pid());
+      pstat_values.push_back(particle->pstat());
+      e_values.push_back(static_cast<float>(particle->e()));
+      px_values.push_back(static_cast<float>(particle->px()));
+      py_values.push_back(static_cast<float>(particle->py()));
+      pz_values.push_back(static_cast<float>(particle->pz()));
     }
 
-    ss  << ipart
-        // << " " << particle->plabel()
-        << " " << particle->pid()
-        << " " << particle->pstat()
-        << " " << particle->e()
-        << " " << particle->px()
-        << " " << particle->py()
-        << " " << particle->pz()
-        << "\n";
-    ++ipart;
+    // Write the number of particles
+    const int num_particles = static_cast<int>(pid_values.size());
+    output_file.write(reinterpret_cast<const char*>(&num_particles), sizeof(int));
+    // Write the pid, pstat, e, px, py, pz values for each particle
+    for (int i = 0; i < num_particles; ++i) {
+      output_file.write(reinterpret_cast<const char*>(&pid_values[i]), sizeof(int));
+      output_file.write(reinterpret_cast<const char*>(&pstat_values[i]), sizeof(int));
+      output_file.write(reinterpret_cast<const char*>(&e_values[i]), sizeof(float));
+      output_file.write(reinterpret_cast<const char*>(&px_values[i]), sizeof(float));
+      output_file.write(reinterpret_cast<const char*>(&py_values[i]), sizeof(float));
+      output_file.write(reinterpret_cast<const char*>(&pz_values[i]), sizeof(float));
+    }
   }
-
-  // Now that we've filtered the particles, we can finally write to the output file.
-  // First, write header
-  // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
-  // NOTE: Could also add Npart, Ncoll, and TotalEntropy. See the original stream writer.
-  // NOTE: ipart == total number of (filtered) particles by the end of the loop, so we can just take advnage of it.
-  output_file << "#"
-      << "\t" << "Event\t" << GetCurrentEvent() + 1  // +1 to index the event count from 1
-      << "\t" << "weight\t" << std::setprecision(15) << GetHeader().GetEventWeight() << std::setprecision(6)
-      << "\t" << "EPangle\t" << (GetHeader().GetEventPlaneAngle() > -999 ? GetHeader().GetEventPlaneAngle() : 0)
-      << "\t" << "N_" << GetName() << "\t" << ipart;
-  if (headerVersion == 3) {
-    output_file
-        << "\t" << "vertex_x\t" << GetHeader().GetVertexX()
-        << "\t" << "vertex_y\t" << GetHeader().GetVertexY()
-        << "\t" << "vertex_z\t" << GetHeader().GetVertexZ();
-  }
-  output_file
-      << centrality_text
-      << pt_hat_text
-      <<  "\n";
-
-  // Finally, write the particles
-  output_file << ss.str();
-
   // Cleanup to be ready for the next event.
   particles.clear();
 }
@@ -156,13 +216,15 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
   std::string name = GetName();
   name[0] = toupper(name[0]);
 
+  // Check if we want to write binary output
+  binaryOutput = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"binary_output"}));
   // Whether to write the centrality and pt hat value for each event
   writeCentrality = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_centrality"}));
   // Whether to write the pt hat value for each event
   writePtHat = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_pthat"}));
 
   // Status codes to filter out from what is written (i.e. to be skipped)
-  // NOTE: Need the capizlied name here!
+  // NOTE: Need the capitalized name here!
   std::string s = JetScapeXML::Instance()->GetElementText({"Writer", (std::string("FinalState") + name).c_str(), "statusToSkip"}, false);
   if (s.size() > 0) {
     particleStatusToSkip = detail::stringToVector(s);
@@ -170,47 +232,71 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
     particleStatusToSkip.erase(std::remove(particleStatusToSkip.begin(), particleStatusToSkip.end(), -9999), particleStatusToSkip.end());
   }
   if (GetActive()) {
-    // We need the header version to determine how to write.
-    // NOTE: Don't require the version. If not specified, defaults to v2.
-    int result = GetXMLElementInt({"Writer", (std::string("FinalState") + name).c_str(), "headerVersion"}, false);
-    // If it fails to retrieve the value, it will return 0. The header version must be >= 2,
-    // so only assign if the value is actually set.
-    if (result) {
-      headerVersion = static_cast<unsigned int>(result);
-    }
-
-    JSINFO << "JetScape Final State " << name << " Stream Writer v" << headerVersion << " initialized with output file = "
-           << GetOutputFileName();
-    output_file.open(GetOutputFileName().c_str());
-    // NOTE: This header will only be printed once at the beginning on the file.
-    output_file << "#"
-        // The specifics the version number. For consistency in parsing, the string
-        // will always be "v<number>"
-        << "\t" << "JETSCAPE_FINAL_STATE\t" << "v" << headerVersion
-        << "\t" << "|"  // As a delimiter
-        << "\t" << "N"
-        << "\t" << "pid"
-        << "\t" << "status"
-        << "\t" << "E"
-        << "\t" << "Px"
-        << "\t" << "Py"
-        << "\t" << "Pz"
-        << "\n";
-
-    // Print the status codes that will be skipped for logging purposes to ensure that
-    // it's clear that the values are propagated correctly.
-    if (particleStatusToSkip.size() > 0) {
-      std::stringstream ss;
-      ss << "Filtering (i.e. removing) " << GetName() << " with status codes: ";
-      unsigned int count = 0;
-      for (const auto status : particleStatusToSkip) {
-        if (count > 0) {
-          ss << ", ";
-        }
-        ss << status;
-        ++count;
+    if (!binaryOutput) {
+      // Writing ascii output
+      // We need the header version to determine how to write.
+      // NOTE: Don't require the version. If not specified, defaults to v2.
+      int result = GetXMLElementInt({"Writer", (std::string("FinalState") + name).c_str(), "headerVersion"}, false);
+      // If it fails to retrieve the value, it will return 0. The header version must be >= 2,
+      // so only assign if the value is actually set.
+      if (result) {
+        headerVersion = static_cast<unsigned int>(result);
       }
-      JSINFO << ss.str();
+      JSINFO << "JetScape Final State " << name << " Stream Writer v" << headerVersion << " initialized with output file = "
+             << GetOutputFileName();
+      // Normal ascii output
+      output_file.open(GetOutputFileName().c_str());
+      // NOTE: This header will only be printed once at the beginning on the file.
+      output_file << "#"
+          // The specifics the version number. For consistency in parsing, the string
+          // will always be "v<number>"
+          << "\t" << "JETSCAPE_FINAL_STATE\t" << "v" << headerVersion
+          << "\t" << "|"  // As a delimiter
+          << "\t" << "N"
+          << "\t" << "pid"
+          << "\t" << "status"
+          << "\t" << "E"
+          << "\t" << "Px"
+          << "\t" << "Py"
+          << "\t" << "Pz"
+          << "\n";
+  
+      // Print the status codes that will be skipped for logging purposes to ensure that
+      // it's clear that the values are propagated correctly.
+      if (particleStatusToSkip.size() > 0) {
+        std::stringstream ss;
+        ss << "Filtering (i.e. removing) " << GetName() << " with status codes: ";
+        unsigned int count = 0;
+        for (const auto status : particleStatusToSkip) {
+          if (count > 0) {
+            ss << ", ";
+          }
+          ss << status;
+          ++count;
+        }
+        JSINFO << ss.str();
+      }
+    } else {
+      // Binary output file
+      output_file.open(GetOutputFileName().c_str(), std::ios::binary);
+      const int binary_file_version = 1;
+      output_file.write(reinterpret_cast<const char*>(&binary_file_version), sizeof(int));
+      // Status codes to skip in the writer, assume that there are at maximum 4
+      // codes to skip. If there is no code to skip, write 666 instead. If there are more than
+      // 4 codes to skip, write the first three and ignore the rest (use JSWARN to message the user).
+      if (particleStatusToSkip.size() > 0) {
+        if (particleStatusToSkip.size() > 4) {
+          JSWARN << "More than 4 status codes to skip. Only the first four will be written to the file.";
+        }
+        int status_codes[4] = {666, 666, 666, 666};
+        for (unsigned int i = 0; i < particleStatusToSkip.size() && i < 4; ++i) {
+          status_codes[i] = particleStatusToSkip[i];
+        }
+        output_file.write(reinterpret_cast<const char*>(&status_codes), sizeof(int) * 4);
+      } else {
+        int status_codes[4] = {666, 666, 666, 666};
+        output_file.write(reinterpret_cast<const char*>(&status_codes), sizeof(int) * 4);
+      }
     }
   }
 }
@@ -244,6 +330,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Write(weak_ptr<Hadron
 }
 
 template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
+  if (!binaryOutput) {
     // Write xsec output at the end.
     // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
     output_file << "#" << "\t"
@@ -252,6 +339,18 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
         << "weight\t"   << GetHeader().GetEventWeight() << "\t"
         << "pT-Hat\t"   << GetHeader().GetPtHat() << "\n";
     output_file.close();
+  } else {
+    // Write xsec output at the end.
+    const float sigmaGen = static_cast<float>(GetHeader().GetSigmaGen());
+    output_file.write(reinterpret_cast<const char*>(&sigmaGen), sizeof(float));
+    const float sigmaErr = static_cast<float>(GetHeader().GetSigmaErr());
+    output_file.write(reinterpret_cast<const char*>(&sigmaErr), sizeof(float));
+    const float weight = static_cast<float>(GetHeader().GetEventWeight());
+    output_file.write(reinterpret_cast<const char*>(&weight), sizeof(float));
+    const float ptHat = static_cast<float>(GetHeader().GetPtHat());
+    output_file.write(reinterpret_cast<const char*>(&ptHat), sizeof(float));
+    output_file.close();
+  }
 }
 
 template class JetScapeWriterFinalStateStream<ofstream>;

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -231,6 +231,22 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
     // Remove the default value, if there
     particleStatusToSkip.erase(std::remove(particleStatusToSkip.begin(), particleStatusToSkip.end(), -9999), particleStatusToSkip.end());
   }
+  // Print the status codes that will be skipped for logging purposes to ensure that
+  // it's clear that the values are propagated correctly.
+  if (particleStatusToSkip.size() > 0) {
+    std::stringstream ss;
+    ss << "Filtering (i.e. removing) " << GetName() << " with status codes: ";
+    unsigned int count = 0;
+    for (const auto status : particleStatusToSkip) {
+      if (count > 0) {
+        ss << ", ";
+      }
+      ss << status;
+      ++count;
+    }
+    JSINFO << ss.str();
+  }
+
   if (GetActive()) {
     if (!binaryOutput) {
       // Writing ascii output
@@ -260,22 +276,6 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
           << "\t" << "Py"
           << "\t" << "Pz"
           << "\n";
-  
-      // Print the status codes that will be skipped for logging purposes to ensure that
-      // it's clear that the values are propagated correctly.
-      if (particleStatusToSkip.size() > 0) {
-        std::stringstream ss;
-        ss << "Filtering (i.e. removing) " << GetName() << " with status codes: ";
-        unsigned int count = 0;
-        for (const auto status : particleStatusToSkip) {
-          if (count > 0) {
-            ss << ", ";
-          }
-          ss << status;
-          ++count;
-        }
-        JSINFO << ss.str();
-      }
     } else {
       // Binary output file
       output_file.open(GetOutputFileName().c_str(), std::ios::binary);

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -217,7 +217,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
   name[0] = toupper(name[0]);
 
   // Check if we want to write binary output
-  binaryOutput = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"binary_output"}));
+  binaryOutput = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"Writer", "JetscapeWriterFinalStateBinaryOutput"}));
   // Whether to write the centrality and pt hat value for each event
   writeCentrality = static_cast<bool>(JetScapeXML::Instance()->GetElementInt({"write_centrality"}));
   // Whether to write the pt hat value for each event
@@ -279,7 +279,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::InitTask() {
     } else {
       // Binary output file
       output_file.open(GetOutputFileName().c_str(), std::ios::binary);
-      const int binary_file_version = 1;
+      const int binary_file_version = 3;
       output_file.write(reinterpret_cast<const char*>(&binary_file_version), sizeof(int));
       // Status codes to skip in the writer, assume that there are at maximum 4
       // codes to skip. If there is no code to skip, write 666 instead. If there are more than
@@ -336,15 +336,14 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
     output_file << "#" << "\t"
         << "sigmaGen\t" << GetHeader().GetSigmaGen() << "\t"
         << "sigmaErr\t" << GetHeader().GetSigmaErr() << "\n";
-    output_file.close();
   } else {
     // Write xsec output at the end.
     const float sigmaGen = static_cast<float>(GetHeader().GetSigmaGen());
     output_file.write(reinterpret_cast<const char*>(&sigmaGen), sizeof(float));
     const float sigmaErr = static_cast<float>(GetHeader().GetSigmaErr());
     output_file.write(reinterpret_cast<const char*>(&sigmaErr), sizeof(float));
-    output_file.close();
   }
+  output_file.close();
 }
 
 template class JetScapeWriterFinalStateStream<ofstream>;

--- a/src/framework/JetScapeWriterFinalStateStream.cc
+++ b/src/framework/JetScapeWriterFinalStateStream.cc
@@ -335,9 +335,7 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
     // NOTE: Needs consistent "\t" between all entries to simplify parsing later.
     output_file << "#" << "\t"
         << "sigmaGen\t" << GetHeader().GetSigmaGen() << "\t"
-        << "sigmaErr\t" << GetHeader().GetSigmaErr() << "\t"
-        << "weight\t"   << GetHeader().GetEventWeight() << "\t"
-        << "pT-Hat\t"   << GetHeader().GetPtHat() << "\n";
+        << "sigmaErr\t" << GetHeader().GetSigmaErr() << "\n";
     output_file.close();
   } else {
     // Write xsec output at the end.
@@ -345,10 +343,6 @@ template <class T> void JetScapeWriterFinalStateStream<T>::Close() {
     output_file.write(reinterpret_cast<const char*>(&sigmaGen), sizeof(float));
     const float sigmaErr = static_cast<float>(GetHeader().GetSigmaErr());
     output_file.write(reinterpret_cast<const char*>(&sigmaErr), sizeof(float));
-    const float weight = static_cast<float>(GetHeader().GetEventWeight());
-    output_file.write(reinterpret_cast<const char*>(&weight), sizeof(float));
-    const float ptHat = static_cast<float>(GetHeader().GetPtHat());
-    output_file.write(reinterpret_cast<const char*>(&ptHat), sizeof(float));
     output_file.close();
   }
 }

--- a/src/framework/JetScapeWriterFinalStateStream.h
+++ b/src/framework/JetScapeWriterFinalStateStream.h
@@ -69,6 +69,7 @@ protected:
   bool writeCentrality;
   bool writePtHat;
   std::vector<int> particleStatusToSkip;
+  bool binaryOutput;
 };
 
 template <class T>


### PR DESCRIPTION
This adds a binary output mode for the final state hadron/parton outputs. It comes in the following form:
```
File header:
1 int: Binary output version (1 at the moment)
4 int: status codes to skip (can store 4 codes to skip [default 666], if more are skipped, then they are ignored and a warning is printed)

Event header:
1 int: event_number
7 float: event_weight, event_plane_angle, vx, vy, vz, centrality, pt_hat (vx/vy/vz are the vertex location)
1 int: num_particles

num_particles particle blocks:
2 int: pid, status
4 float: e, px, py, pz

File footer:
2 float: sigmaGen, sigmaErr
```
This output includes the maximum amount of information that can be written in the current form of the ASCII output.
@raymondEhlers This PR also removes the writing of the `event_weight` and `pt_hat` in the file footer, since this was just repeating the values from the last event in the file and breaking the compatibility with the JS output.

I made a test with 25k events using the `jetscape_user_nPDF_test` XML file, and the output has 80MB in ASCII format and 42.2MB in the new binary format.