### PR TITLE
Fix hydro multiple events

### DIFF
--- a/src/framework/FluidDynamics.cc
+++ b/src/framework/FluidDynamics.cc
@@ -82,6 +82,7 @@ void FluidDynamics::ClearTask() {
   if (!weak_ptr_is_uninitialized(liquefier_ptr)) {
     liquefier_ptr.lock()->ClearTask();
   }
+  hydro_status = NOT_START;
 }
 
 void FluidDynamics::CollectHeader(weak_ptr<JetScapeWriter> w) {

--- a/src/hydro/MusicWrapper.cc
+++ b/src/hydro/MusicWrapper.cc
@@ -304,7 +304,8 @@ void MpiMusic::EvolveHydro() {
     has_source_terms = true;
   }
 
-  if (flag_preEq_output_evo_to_memory == 1 && pre_eq_ptr != nullptr) {
+  if (flag_preEq_output_evo_to_memory == 1 
+    && pre_eq_ptr != nullptr && initialProfile_ == 42) {
     double tau0 = pre_eq_ptr->GetPreequilibriumEndTime();
     JSINFO << "Hydro initial time set by pre-equilibrium module tau0 = "
            << tau0 << " fm/c";


### PR DESCRIPTION
This adds:
- Reset the `hydro_status` to `NOT_START` after each event to allow for the initialization of the next hydro event.
- Add a safety check to enter pre-equilibrium block only if the initial profile is set to 42 (Trento+FS).