### PR TITLE
Updated lines to read flag in JetHadronization

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -532,9 +532,9 @@
        <weak_decays>depracted</weak_decays> <!-- use the parameters pythia_decays and tau0Max, this parameter is only a dummy to make old xml files work-->
        <!-- You can add any number of additional lines to initialize pythia hadronization here -->
        <!-- Note that if the tag exists it cannot be empty (tinyxml produces a segfault) -->
-       <!-- <LinesToRead> -->
-       <!--   111:mayDecay = off  -->
-       <!-- </LinesToRead> -->
+       <LinesToRead>
+          Init:showProcesses = off 
+       </LinesToRead> 
        <reco_hadrons_in_pythia>1</reco_hadrons_in_pythia>
        <!-- Switch to include more pythia particles from an additional xml file with particle information -->
        <additional_pythia_particles>0</additional_pythia_particles>


### PR DESCRIPTION
Redundantly read in a non-physics parameter that hadronization modules set so that users do not need to modify the main xml file to read lines into Pythia for hadronization.

Previously to read in lines to pythia for the hadronization modules, users would have to uncomment the lines to read flag in the main xml. This was done to avoid tinyxml having a segmentation fault, but one can just read in a setting redundantly instead to avoid this. 