### PR TITLE
Redefine safety checks for pre-equilibrium module

### DIFF
--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -422,7 +422,7 @@
     <MUSIC>
       <name>MUSIC</name>
       <MUSIC_input_file>music_input</MUSIC_input_file>
-      <!--InitialProfile = 42 for Trento + Pre-equilibrium, 13 for the 3D Glauber initial condition-->
+      <!--InitialProfile = 42 for Trento + Pre-equilibrium or IPGlasma, 13 for the 3D Glauber initial condition-->
       <InitialProfile>42</InitialProfile>
       <!--beastMode = 0: double precision, constant time step-->
       <!--beastMode = 1: float precision, constant time step-->

--- a/src/framework/FluidDynamics.cc
+++ b/src/framework/FluidDynamics.cc
@@ -53,12 +53,22 @@ void FluidDynamics::Init() {
            << "jetscape->Add(trento);";
     exit(-1);
   }
-
-  pre_eq_ptr =
-      JetScapeSignalManager::Instance()->GetPreEquilibriumPointer().lock();
-  if (!pre_eq_ptr and GetId()!="Brick") {
-    JSWARN << "No Pre-equilibrium module";
-    exit(-1);
+  //Check if pre-equilibrium module is needed and set pointer
+  bool needs_pre_eq = true;
+  if (GetId()=="MUSIC"){
+    int hydro_profile = GetXMLElementDouble({"Hydro", "MUSIC", "InitialProfile"});
+    if (hydro_profile!=42){needs_pre_eq = false;} //Only 42 needs pre-equilibrium
+  }
+  else if (GetId()=="Brick"){needs_pre_eq = false;} 
+  else {
+    JSWARN << "Unrecognized hydro module id:" << GetId()
+           << "Assuming pre_equilibrium moudle is needed.";
+  }
+  // If pre-equilibrium module is needed but not attached, warn and exit
+  if (needs_pre_eq and !pre_eq_ptr){
+    JSWARN << "No pre-equilibrium module attached."
+           << "Check your Hydro InitialProfile.";
+           exit(-1);
   }
 
   InitializeHydro(parameter_list);


### PR DESCRIPTION
Previous logic allowed brick to run, but not MUSIC without pre-equilibrium for some useage cases (e.g. strings from Glauber passed to hydro).