### PR TITLE
Updated hash to fix misleading energy print

### DIFF
--- a/external_packages/get_music.sh
+++ b/external_packages/get_music.sh
@@ -16,7 +16,7 @@
 
 # using a commit from the MUSIC repository that is compatible with the current X-SCAPE version
 folderName="music"
-commitHash="132448235467999067f1c01f340736139499ce16"
+commitHash="72b2e0c3ee2bbd1ec5873c8e4d363d4abce51944"
 
 git clone https://github.com/MUSIC-fluid/MUSIC.git -b JETSCAPE $folderName
 cd $folderName


### PR DESCRIPTION
Change in MUSIC to fix a misleading energy printout for the total energy which would usually be greater than the collision energy. This will not affect any final state observables according to @chunshen1987 because the energy from the strings is normalized before the hydro starts, and a test event yielded the same distribution of energy between strings and remnants.  