### PR TITLE
Update MacOS Automated Test Workflow

### DIFF
--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -161,7 +161,14 @@ jobs:
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}
-        cmake .. -DUSE_3DGlauber=ON -DUSE_MUSIC=ON -DUSE_ISS=ON -DUSE_FREESTREAM=ON -DUSE_SMASH=ON
+        cmake .. \
+          -DUSE_3DGlauber=ON \
+          -DUSE_MUSIC=ON \
+          -DUSE_ISS=ON \
+          -DUSE_FREESTREAM=ON \
+          -DUSE_SMASH=ON \
+          -DCMAKE_PREFIX_PATH="$BOOST_ROOT" \
+          -DBoost_NO_BOOST_CMAKE=ON
         make -j2
 
     - name: Test Run

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-1.2.1-RC
+      - latessa/macos_workflow_boost_pin
 
   push:
     branches:
       - main
       - XSCAPE-1.2.1-RC
+      - latessa/macos_workflow_boost_pin
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}
@@ -35,7 +37,7 @@ jobs:
         brew install --formula hdf5
         brew install --formula open-mpi
         brew install --formula gsl
-        brew install --formula boost
+        brew install --formula boost@1.78
         brew install --formula zlib
         brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
@@ -155,6 +157,7 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        BOOST_ROOT="$(brew --prefix boost@1.78)"
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -37,7 +37,7 @@ jobs:
         brew install --formula hdf5
         brew install --formula open-mpi
         brew install --formula gsl
-        brew install --formula boost@1.78
+        brew install --formula boost@1.85
         brew install --formula zlib
         brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
@@ -157,7 +157,7 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
-        BOOST_ROOT="$(brew --prefix boost@1.78)"
+        BOOST_ROOT="$(brew --prefix boost@1.85)"
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
         ls ${SMASH_DIR}


### PR DESCRIPTION
This change accommodates a MacOS homebrew update that affects how cmake looks for boost. The issue only affects native MaOS installations, so the automated native MacOS workflow is amended here.