### PR TITLE
Fix native MacOS build issue concerning SMASH and the new Eigen 5

### DIFF
--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -36,16 +36,28 @@ jobs:
         brew install --formula open-mpi
         brew install --formula gsl
         brew install --formula boost@1.85
+        brew install --formula eigen
         brew install --formula zlib
         brew install --formula gcc
         . /opt/homebrew/bin/thisroot.sh
 
     - name: set environment variables
       run: |
-        export ROOTSYS="/usr/local/root"
-        export PATH="$ROOTSYS/bin:\$PATH"
-        export LD_LIBRARY_PATH="$ROOTSYS/lib:$LD_LIBRARY_PATH"
-        export PYTHONPATH="$ROOTSYS/lib"
+        echo "ROOTSYS=/usr/local/root" >> $GITHUB_ENV
+        echo "PATH=/usr/local/root/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/usr/local/root/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=/usr/local/root/lib" >> $GITHUB_ENV
+
+    - name: Capture Eigen paths
+      run: |
+        EIGEN_PREFIX="$(brew --prefix eigen)"
+        echo "EIGEN3_PREFIX=${EIGEN_PREFIX}" >> $GITHUB_ENV
+        echo "EIGEN3_ROOT=${EIGEN_PREFIX}/include" >> $GITHUB_ENV
+        echo "EIGEN3_INCLUDE_DIR=${EIGEN_PREFIX}/include/eigen3" >> $GITHUB_ENV
+        echo "EIGEN3_CMAKE_DIR=${EIGEN_PREFIX}/share/eigen3/cmake" >> $GITHUB_ENV
+        echo "Eigen3_DIR=${EIGEN_PREFIX}/share/eigen3/cmake" >> $GITHUB_ENV
+        echo "EIGEN3_ROOT_DIR=${EIGEN_PREFIX}/include" >> $GITHUB_ENV
+        echo "Eigen paths registered from ${EIGEN_PREFIX}"
 
     - name: Download CMake 3.31.6
       run: |
@@ -96,6 +108,8 @@ jobs:
           ../hepmc3-source
         make
         make install
+        echo "HEPMC3_DIR=${GITHUB_WORKSPACE}/hepmc3-install" >> $GITHUB_ENV
+        echo "Set HEPMC3_DIR=${GITHUB_WORKSPACE}/hepmc3-install"
 
     - name: Download Pythia 8315
       run: |
@@ -139,6 +153,7 @@ jobs:
 
     - name: Download SMASH
       run: |
+        export CMAKE_PREFIX_PATH="${EIGEN3_CMAKE_DIR}:$CMAKE_PREFIX_PATH"
         echo "JETSCAPE_DIR is $JETSCAPE_DIR"
         echo "PYTHIA8DIR is $PYTHIA8DIR"
         cd ${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages
@@ -155,6 +170,7 @@ jobs:
         mkdir build
         cd build
         export SMASH_DIR="${GITHUB_WORKSPACE}/${REPO_NAME}/external_packages/smash/smash_code"
+        export CMAKE_PREFIX_PATH="${EIGEN3_CMAKE_DIR}:$CMAKE_PREFIX_PATH"
         BOOST_ROOT="$(brew --prefix boost@1.85)"
         echo "This is SMASH_DIR: "
         echo ${SMASH_DIR}
@@ -165,7 +181,7 @@ jobs:
           -DUSE_ISS=ON \
           -DUSE_FREESTREAM=ON \
           -DUSE_SMASH=ON \
-          -DCMAKE_PREFIX_PATH="$BOOST_ROOT" \
+          -DCMAKE_PREFIX_PATH="$BOOST_ROOT;$EIGEN3_CMAKE_DIR" \
           -DBoost_NO_BOOST_CMAKE=ON
         make -j2
 

--- a/external_packages/get_smash.sh
+++ b/external_packages/get_smash.sh
@@ -21,7 +21,19 @@ git clone --depth=1 https://github.com/smash-transport/smash.git --branch SMASH-
 cd smash/smash_code
 mkdir build
 cd build
-cmake .. -DPythia_CONFIG_EXECUTABLE=${PYTHIA8DIR}/bin/pythia8-config
+cmake_args=(
+	-DPythia_CONFIG_EXECUTABLE=${PYTHIA8DIR}/bin/pythia8-config
+)
+
+if [[ -n "${Eigen3_DIR}" ]]; then
+	cmake_args+=( -DEigen3_DIR=${Eigen3_DIR} )
+fi
+
+if [[ -n "${EIGEN3_INCLUDE_DIR}" ]]; then
+	cmake_args+=( -DEIGEN3_INCLUDE_DIR=${EIGEN3_INCLUDE_DIR} )
+fi
+
+cmake .. "${cmake_args[@]}"
 num_cores=${1:-1}
 echo "Compiling SMASH using ${num_cores} cores."
 make -j${num_cores} smash_shared


### PR DESCRIPTION
This PR resolves the build issue on MacOS that arose when Eigen was updated from version 3.X to 5. With these changes, the Eigen path is passed to cmake in the get_smash script.