### PR TITLE
run build test on both AMD64 and ARM64 instances

### DIFF
--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
     
     steps:

--- a/.github/workflows/smash_test_completes.yaml
+++ b/.github/workflows/smash_test_completes.yaml
@@ -5,11 +5,14 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
+
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-external.yaml
+++ b/.github/workflows/test-build-external.yaml
@@ -16,11 +16,19 @@ env:
 
 jobs:
   build:
-    name: external packages
-    runs-on: ubuntu-latest
+    name: external packages (${{ matrix.arch }})
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runs-on }}
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
 
     steps:

--- a/.github/workflows/test-build-macos-native.yaml
+++ b/.github/workflows/test-build-macos-native.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
       
     steps:

--- a/.github/workflows/test-build-nPDF.yaml
+++ b/.github/workflows/test-build-nPDF.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-code-format.yaml
+++ b/.github/workflows/test-code-format.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 env:
   REPO_NAME: ${{ github.event.repository.name }}
 

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-PbPb.yaml
+++ b/.github/workflows/test-events-PbPb.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: main
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
 
     - name: Run Pb-Pb tests

--- a/.github/workflows/test-events-Pythia-Isr-Dat.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Dat.yaml
@@ -7,11 +7,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Hadron.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-Pythia-Isr-Parton.yaml
+++ b/.github/workflows/test-events-Pythia-Isr-Parton.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
 
     steps:
@@ -47,7 +47,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: jetscape-4.0.1
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
 
     - name: Run Brick Matter Lbt tests

--- a/.github/workflows/test-events-brick.yaml
+++ b/.github/workflows/test-events-brick.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jetscape/base:v1.13
+      image: jetscape/base:v2.0
       options: --user root
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: JETSCAPE/TEST-EXAMPLES
-        ref: main
+        ref: jetscape-4.0.2
         path: TEST-EXAMPLES
 
     - name: Run pp tests

--- a/.github/workflows/test-events-pp.yaml
+++ b/.github/workflows/test-events-pp.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
   push:
     branches:
       - main
       - XSCAPE-2.1-RC
+      - latessa/multi-arch-build-test
 
 env:
   REPO_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
Since our supported Docker image will be based on Alma Linux and include multi-arch support as of the X-SCAPE 2.1 release, this PR adds an ARM64 runner to the automated build test.