### PR TITLE
avoid seg fault if arrays are not allocated

### DIFF
--- a/external_packages/hydro_from_external_file/Hydroinfo_h5.cpp
+++ b/external_packages/hydro_from_external_file/Hydroinfo_h5.cpp
@@ -36,6 +36,7 @@ HydroinfoH5::~HydroinfoH5() {
 }
 
 void HydroinfoH5::clean_hydro_event() {
+    if (readinFlag == 0) return;
     for (int i=0; i<Buffersize; i++) {
         for (int j=0; j<dimensionX; j++) {
            delete[] ed[i][j];


### PR DESCRIPTION
This PR applies a bug fix already submitted to C-SCAPE to avoid seg fault if arrays are not allocated.
https://github.com/JETSCAPE/C-SCAPE-COMP/pull/1