### PR TITLE
reset hydro grid information to zero when clear up the evolution history

### DIFF
--- a/src/framework/FluidEvolutionHistory.h
+++ b/src/framework/FluidEvolutionHistory.h
@@ -221,7 +221,21 @@ class EvolutionHistory {
   /**
    * @brief Clear the evolution history data.
    */
-  void clear_up_evolution_data() { data.clear(); }
+  void clear_up_evolution_data() {
+      data.clear();
+      ntau = 0;
+      nx = 0;
+      ny = 0;
+      neta = 0;
+      dtau = 0;
+      dx = 0;
+      dy = 0;
+      deta = 0;
+      tau_min = 0;
+      x_min = 0;
+      y_min = 0;
+      eta_min = 0;
+  }
 
   /**
    * @brief Get the size of the data vector.


### PR DESCRIPTION
When one event does not have the bulk evolution, the hydro wrapper only clears up the evolution history, but does not reset the hydro grid information. It will cause a segmentation fault. This pull request fixes it by resetting all the grid information to 0 when clearing the evolution history.