### PR TITLE
Enable parallel runs from one build via XSCAPE_DATA_DIR + launcher

### DIFF
--- a/PlanInstall.md
+++ b/PlanInstall.md
@@ -1,0 +1,211 @@
+# X-SCAPE: genuine install + parallel runs without per-run build dirs
+
+## Context
+
+Today X-SCAPE is run directly from inside a `build/` directory. To run several
+instances at once, users currently create several full build directories,
+because every module resolves its files relative to the current working
+directory (CWD = the build dir):
+
+- **Read-only assets** (executable, libs, EOS tables, iSS tables, LBT tables,
+  3dMCGlauber tables, config XML, input files) are materialized into the build
+  dir at *configure* time via `file(COPY)` / `configure_file` / symlink, and
+  looked up CWD-relative at runtime.
+- **Writable outputs** use fixed names in CWD (`surface.dat`,
+  `events_summary.dat`, `OSCAR.DAT`, `evolution_all_xyeta.dat`, …), and MUSIC
+  even **rewrites its input file in place** (`update_music_input_parameter`).
+
+So two concurrent runs in the same dir collide. The fix is to (1) relocate
+read-only assets into a shared install prefix discoverable via one env var, and
+(2) let each run execute in its own *empty, lightweight* working directory for
+writable output. Then "multiple instances at once" = multiple cheap run dirs
+against one install — no rebuilds, no duplicate build trees.
+
+**Decisions (confirmed with user):** staged delivery (MVP first, full install
+second); make the *whole* framework relocatable; single data-root env var
+`XSCAPE_DATA_DIR` (extending the existing `HYDROPROGRAMPATH` pattern), set by a
+launcher.
+
+## What already works (no code change)
+
+- **MUSIC EOS** already honors env var `HYDROPROGRAMPATH`
+  (`external_packages/music/src/eos_base.cpp` `get_hydro_env_path()`, default
+  `"."`). Map `HYDROPROGRAMPATH=$XSCAPE_DATA_DIR`.
+- **iSS** is fully XML-redirectable: `iSS_table_path`,
+  `iSS_particle_table_path`, `iSS_input_file`, `iSS_working_path`
+  (`src/hadronization/iSpectraSamplerWrapper.cc` → `external_packages/iSS/src/iSS.cpp`).
+- **3dMCGlauber sample caches** (`tables/{proton,neutron}_valence_quark_samples*.dat`)
+  are READ-only with the shipped default `cache_tables 1`
+  (`external_packages/3dMCGlauber/src/Parameters.cpp` `get_cached_tabels()`); the
+  `rm`/regen path (`Glauber.cpp`, `Nucleus.cpp` `system("./Metropolis.e …")`)
+  only fires when `cache_tables 0` or files are missing. Keep `cache_tables 1`
+  and ship the caches → runs never write `tables/`.
+- **Primary JETSCAPE outputs** (ascii/hepmc/root) are already XML-configurable
+  via `<outputFilename>` (`src/framework/JetScape.cc`).
+
+## True blockers (need code) for full relocation
+
+- **`mcglauber.input` hard-coded** — `src/initialstate/MCGlauberWrapper.cc:45-46`
+  (`new MCGlb::EventGenerator("mcglauber.input", …)`).
+- **`LBT-tables/` hard-coded** — `src/jet/LBT.cc:95-96` and the `ifstream("LBT-tables/…")`
+  reads in `read_tables()` (ratedata, ratedata-HQ, dNg_over_dt_*, distB/F).
+- **3dMCGlauber CWD-relative dirs** `tables/`, `eps09/`, `LHAPDF_Lib` (vendored
+  sources). Handled by launcher symlink (preferred — avoids editing vendored
+  code); deeper code change optional/deferred.
+- **MUSIC input in-place rewrite** — `MusicWrapper.cc:105,224` + defn `727-778`.
+  Handled by giving each run a *local copy* of `music_input` (see Phase 1.3),
+  which also preserves the MUSIC↔iSS shared-file coupling.
+
+---
+
+## Phase 1 — MVP: parallel runs against the existing build dir
+
+Goal: run unlimited concurrent instances against ONE existing build dir, each in
+its own empty CWD. No bin/lib/share refactor yet. The build dir acts as
+`$XSCAPE_DATA_DIR`.
+
+1. **Data-root helper (framework).** Add a tiny helper that returns the data
+   root: `getenv("XSCAPE_DATA_DIR")`, else a baked default (Phase 2), else `"."`.
+   Put it where both initial-state and jet modules can use it (e.g. a small
+   function in `src/framework`). Reuse for the two code blockers below.
+
+2. **3dMCGlauber input path configurable (CODE).**
+   `src/initialstate/MCGlauberWrapper.cc:45-46` — resolve the input file via a
+   new XML element `{"IS","MCGlauber","mcglauber_input_file"}` (fallback
+   `"mcglauber.input"`, optionally prefixed by the data-root helper); pass to the
+   `EventGenerator` ctor. Add `<mcglauber_input_file>` under `IS/MCGlauber` in
+   `config/jetscape_main.xml`.
+
+3. **LBT-tables dir configurable (CODE).** `src/jet/LBT.cc` — in `InitTask()`
+   resolve a base dir once: env `LBT_TABLES_PATH` → else data-root helper +
+   `/LBT-tables` → else `"LBT-tables"`. Prefix `setParameter(dir+"/LBT.input")`
+   (L95-96) and every `ifstream("LBT-tables/…")` in `read_tables()`. Add
+   `<LBT_table_path>` under `Eloss/Lbt` as an alternative knob. (Leave the
+   standalone-only `../hydroProfile/...` path untouched.)
+
+4. **MUSIC input → per-run local copy (LAUNCHER, no code).** The launcher copies
+   the shared `music_input` into the run CWD and points `<MUSIC_input_file>` at
+   that local copy, with `<iSS_working_path>` = the run CWD. Since MUSIC rewrites
+   whatever `MUSIC_input_file` points at, and iSS symlinks that same path into
+   `iSS_working_path/music_input`, the per-run local copy keeps the shared copy
+   read-only while preserving the coupling.
+
+5. **Launcher script (NEW FILE)** e.g. `examples/run_in_workdir.sh`. Per run:
+   - `mkdir -p $RUNDIR && cd $RUNDIR`
+   - `export XSCAPE_DATA_DIR=<build-or-prefix>`; `export HYDROPROGRAMPATH=$XSCAPE_DATA_DIR`;
+     `export LBT_TABLES_PATH=$XSCAPE_DATA_DIR/LBT-tables`
+   - symlink read-only CWD-relative dirs: `tables`, `eps09`, `LHAPDF_Lib`,
+     `nucleusConfigs`, `data_table`
+   - `cp $XSCAPE_DATA_DIR/music_input ./music_input` (writable per-run — NOT a symlink)
+   - run `runJetscape <abs user.xml> <abs main.xml>`; outputs land in `$RUNDIR`.
+
+After Phase 1: parallel instances work from one build dir; outputs isolated;
+shared assets read-only.
+
+---
+
+## Phase 2 — Full clean `bin/ lib/ share/` install
+
+1. **Install prefix + GNUInstallDirs** (`CMakeLists.txt`). Remove/relax the block
+   (~L229-234) that FORCES `CMAKE_INSTALL_PREFIX` to the build dir. Add
+   `include(GNUInstallDirs)`; define `XSCAPE_DATADIR = ${CMAKE_INSTALL_DATADIR}/xscape`.
+
+2. **Install executables via TARGETS** (`CMakeLists.txt`).
+   `install(TARGETS runJetscape … RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})`;
+   gate optional MUSIC/iSS/Isr test executables behind their existing `if()`
+   blocks. Build-tree `EXECUTABLE_OUTPUT_PATH` (L545) may stay for dev.
+
+3. **Install libraries via TARGETS — replace the DIRECTORY copy hack**
+   (`CMakeLists.txt:307-323`). Use `install(TARGETS …)` for the export list at
+   L732-751 (`JetScape JetScapeThird GTL libtrento Cornelius` + conditional
+   `hydroFromFile ipglasma_lib 3dMCGlb music iSS clviscwrapper`) plus
+   `JetScapeReader`, into `${CMAKE_INSTALL_LIBDIR}`. Fix sub-package CMakes that
+   install into `${CMAKE_HOME_DIRECTORY}`:
+   `external_packages/iSS/src/CMakeLists.txt`,
+   `external_packages/3dMCGlauber/src/CMakeLists.txt` (incl. `Metropolis.e`),
+   `external_packages/music/src/CMakeLists.txt` → bindir/libdir.
+
+4. **Install config + data to share/xscape** (alongside the existing configure-time
+   `file(COPY)` at L646-725; both coexist — copies for in-build dev, `install()`
+   for the relocatable tree):
+   - `config/` → `${XSCAPE_DATADIR}/config`
+   - `external_packages/music/EOS/` → `.../EOS`; `examples/test_music_files/music_input` → `.../music_input`
+   - `external_packages/iSS/iSS_tables/` → `.../iSS_tables`; `iSS_parameters.dat` → `.../`
+   - `external_packages/3dMCGlauber/{tables,eps09,LHAPDF_Lib}/` → `.../…`;
+     `external_packages/3dMCGlauber/input` → `.../mcglauber.input` (rename)
+   - `external_packages/trento/nucleusConfigs/`, `src/initialstate/data_table/`,
+     `external_packages/LBT-tables/` (guard `EXISTS`) → `.../…`
+
+5. **Bake the data root + env override** (single mechanism). `configure_file` a
+   generated header (`XscapeInstallPaths.h.in`) with
+   `#define XSCAPE_INSTALL_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/xscape"`. The
+   data-root helper (Phase 1.1) prefers `getenv("XSCAPE_DATA_DIR")`, else this
+   baked default, else `"."`. `examples/runJetscape.cc:58-59`: fall back to
+   `XSCAPE_INSTALL_DATADIR "/config/…"` when `../config/…` is absent (keep argv
+   override). Installed `config/jetscape_main.xml` uses absolute
+   `$XSCAPE_DATA_DIR/...` paths for iSS / MUSIC input / mcglauber input.
+
+6. **RPATH so installed `runJetscape` finds `<prefix>/lib`** (`CMakeLists.txt`,
+   before targets):
+   ```
+   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+   set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+   if(APPLE)
+     set(CMAKE_MACOSX_RPATH ON)
+     set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+   else()
+     set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+   endif()
+   ```
+   Reconcile the 3dMCGlauber sub-CMake `INSTALL_RPATH` (references
+   `${CMAKE_HOME_DIRECTORY}/LHAPDF_Lib/lib/`) so LHAPDF resolves at the prefix.
+   Ensure all shared libs install to one `${CMAKE_INSTALL_LIBDIR}`.
+
+7. **Install the launcher** to `${CMAKE_INSTALL_BINDIR}`, defaulting
+   `XSCAPE_DATA_DIR` to the baked `${CMAKE_INSTALL_FULL_DATADIR}/xscape`.
+
+---
+
+## Critical files
+
+- `/Users/du8478/JetScape/X-SCAPE/CMakeLists.txt` (install layout, RPATH, data install)
+- `/Users/du8478/JetScape/X-SCAPE/src/CMakeLists.txt` (lib install, data_table)
+- `/Users/du8478/JetScape/X-SCAPE/src/initialstate/MCGlauberWrapper.cc` (mcglauber.input path)
+- `/Users/du8478/JetScape/X-SCAPE/src/jet/LBT.cc` (LBT-tables path)
+- `/Users/du8478/JetScape/X-SCAPE/src/hydro/MusicWrapper.cc` (in-place rewrite; per-run copy strategy)
+- `/Users/du8478/JetScape/X-SCAPE/examples/runJetscape.cc` (config XML fallback)
+- `/Users/du8478/JetScape/X-SCAPE/config/jetscape_main.xml` (new path knobs)
+- new: `examples/run_in_workdir.sh`, `XscapeInstallPaths.h.in`
+
+## Verification
+
+1. **Install tree:** `cmake -S . -B /tmp/xbuild -DUSE_MUSIC=ON -DUSE_ISS=ON
+   -DUSE_3DGlauber=ON -DCMAKE_INSTALL_PREFIX=/tmp/xprefix && cmake --build
+   /tmp/xbuild -j && cmake --install /tmp/xbuild`. Confirm
+   `/tmp/xprefix/{bin/runJetscape, lib/libJetScape.*, share/xscape/{config,EOS,
+   iSS_tables,LBT-tables,tables,eps09,LHAPDF_Lib,nucleusConfigs,data_table,
+   mcglauber.input,music_input}}`. `otool -L` / `readelf -d` shows rpath →
+   `<prefix>/lib`; run with empty `DYLD_/LD_LIBRARY_PATH`.
+2. **Single run, arbitrary empty CWD:** launcher + a 3DGlauber+MUSIC+iSS user XML
+   (e.g. `config/jetscape_user_3DGlauber_MUSIC_iSS_*.xml`). Outputs only in the
+   run dir; assert shared `music_input` and `tables/*samples*.dat` mtimes
+   unchanged.
+3. **Two concurrent runs:** two run dirs, distinct seeds / `<outputFilename>`.
+   Both finish; outputs differ; NO shared-asset mtime changed; diff the dirs.
+
+## Risks / flags
+
+- **LBT** unusable from a shared tree without Phase 1.3; static table reads done
+  once.
+- **`cache_tables 0`** is incompatible with shared read-only assets / parallel
+  runs (it `rm`s + regenerates `tables/` and would race). Document: keep
+  `cache_tables 1`.
+- **3dMCGlauber `Metropolis.e`** uses a literal `./` (`Nucleus.cpp`); only fires
+  if sample files missing — shipped caches + symlinked `tables/` avoid it.
+- **MUSIC `music.cpp`** does `rm surface*.dat` + fixed-name outputs — safe only
+  because each run owns its CWD; never run two instances in one dir.
+- **Vendored `external_packages/*`**: prefer launcher symlinks + framework-side
+  wrappers over editing vendored sources, to ease future re-syncs.
+- Sub-package CMakes install into `${CMAKE_HOME_DIRECTORY}` and trento creates a
+  `bin/`; apply the Phase 2.3 redirects consistently or the layout will be
+  inconsistent.

--- a/README_Launcher.md
+++ b/README_Launcher.md
@@ -1,0 +1,132 @@
+# Running multiple X-SCAPE instances in parallel
+
+This document describes how to run several `runJetscape` simulations
+**concurrently from a single build (or install) tree**, each in its own working
+directory. Previously this required creating a separate full build directory per
+concurrent run, because every module looked up its data files and wrote its
+output relative to the current working directory (CWD), so two runs in the same
+directory collided.
+
+Phase 1 of the install refactor makes the read-only data assets locatable from a
+shared prefix and provides a launcher that gives each run an isolated working
+directory. See `PlanInstall.md` for the full roadmap (Phase 2 adds a proper
+`make install` with a `bin/ lib/ share/` layout).
+
+## The model
+
+* **Read-only assets are shared.** EOS tables, iSS tables, LBT tables,
+  3dMCGlauber inputs/tables, the config XML, etc. live once in a shared "data
+  directory" (for an in-build run this is simply the build directory).
+* **Each run gets its own working directory.** All writable output and the few
+  files a module rewrites in place stay in that per-run directory, so concurrent
+  runs never collide.
+
+## How assets are located
+
+| Asset | Resolution (first match wins) |
+|-------|-------------------------------|
+| 3dMCGlauber `mcglauber.input` | XML `IS/MCGlauber/mcglauber_input_file` → `$XSCAPE_DATA_DIR/mcglauber.input` → `./mcglauber.input` |
+| MUSIC EOS tables | env `HYDROPROGRAMPATH` (set to the data dir) → `./EOS` |
+| LBT tables | XML `Eloss/Lbt/LBT_table_path` → env `LBT_TABLES_PATH` → `$XSCAPE_DATA_DIR/LBT-tables` → `./LBT-tables` |
+| iSS tables / parameters | XML `SoftParticlization/iSS/iSS_table_path`, `iSS_input_file`, … (the launcher rewrites these to absolute paths) |
+| MUSIC input file | XML `Hydro/MUSIC/MUSIC_input_file` (CWD-relative `music_input`; the launcher copies a writable per-run copy) |
+
+`XSCAPE_DATA_DIR` (default `.`) is the single framework-wide knob introduced for
+this. When it is unset, every fallback reduces to the historical
+build-directory behavior, so existing workflows are unaffected.
+
+### New optional XML knobs
+
+Two documented-but-inactive knobs were added to `config/jetscape_main.xml`. Add
+them with an explicit path to override; **do not leave them empty** (an empty XML
+element is unsupported and will crash the parser):
+
+```xml
+<IS>
+  <MCGlauber>
+    <mcglauber_input_file>/abs/path/mcglauber.input</mcglauber_input_file>
+    ...
+  </MCGlauber>
+</IS>
+
+<Eloss>
+  <Lbt>
+    <LBT_table_path>/abs/path/LBT-tables</LBT_table_path>
+    ...
+  </Lbt>
+</Eloss>
+```
+
+## The launcher: `examples/run_in_workdir.sh`
+
+The launcher wires the model together for one run. For each invocation it:
+
+1. creates the per-run working directory (`-w`);
+2. writes a per-run copy of the main XML with the iSS paths rewritten to
+   absolute locations under the data dir;
+3. copies `music_input` into the run directory (MUSIC rewrites it in place, so
+   it must be per-run);
+4. symlinks the read-only directories the vendored code still reads CWD-relative
+   (`tables`, `eps09`, `LHAPDF_Lib`, `nucleusConfigs`, `data_table`);
+5. exports `XSCAPE_DATA_DIR`, `HYDROPROGRAMPATH`, and `LBT_TABLES_PATH`;
+6. runs `runJetscape <user.xml> <per-run main.xml>` with the run directory as CWD.
+
+### Usage
+
+```
+examples/run_in_workdir.sh -w RUN_DIR -u USER_XML [-d DATA_DIR] [-b RUNJETSCAPE] [-m MAIN_XML]
+
+  -w RUN_DIR      Per-run working directory (created if missing). REQUIRED.
+  -u USER_XML     User XML config. REQUIRED.
+  -d DATA_DIR     Shared asset prefix. Default: $XSCAPE_DATA_DIR if set,
+                  else the directory containing the runJetscape executable.
+  -b RUNJETSCAPE  Path to runJetscape. Default: DATA_DIR/runJetscape.
+  -m MAIN_XML     Main XML config. Default: DATA_DIR/config/jetscape_main.xml,
+                  else DATA_DIR/../config/jetscape_main.xml (in-build layout).
+```
+
+### Single run
+
+```bash
+# Build tree at ./build, run in /tmp/run1
+examples/run_in_workdir.sh \
+  -d "$PWD/build" \
+  -w /tmp/run1 \
+  -u "$PWD/config/jetscape_user_3DGlauber_MUSIC_iSS_SMASH_test.xml"
+```
+
+### Many runs in parallel (one build tree)
+
+```bash
+BUILD="$PWD/build"
+USER_XML="$PWD/config/jetscape_user_3DGlauber_MUSIC_iSS_SMASH_test.xml"
+for i in $(seq 1 8); do
+  examples/run_in_workdir.sh -d "$BUILD" -w "/tmp/runs/run_$i" -u "$USER_XML" \
+    > "/tmp/runs/run_$i.log" 2>&1 &
+done
+wait
+```
+
+Each `/tmp/runs/run_$i` ends up with its own `event.dat`, `events_summary.dat`,
+`strings_event_*.dat`, `surface_eps_*`, freeze-out/eccentricity files, etc. The
+shared assets in `$BUILD` are never modified. Give each run a distinct
+`<Random><seed>` and/or `<outputFilename>` in the user XML if you want
+statistically independent events.
+
+## Notes & limitations
+
+* **`config/` location for in-build runs.** The build dir does *not* contain
+  `config/` (it lives at the source root). The launcher falls back to
+  `DATA_DIR/../config/jetscape_main.xml`, which works when the build directory is
+  inside the source tree (e.g. `X-SCAPE/build`). For an out-of-source build, pass
+  `-m <source>/config/jetscape_main.xml` explicitly. Phase 2 installs `config/`
+  under `share/xscape` so the default resolves automatically.
+* **3dMCGlauber `tables/` must stay read-only.** Keep `cache_tables 1` (the
+  shipped default) so the valence-quark sample tables are only read, never
+  rewritten/regenerated. `cache_tables 0` is incompatible with shared assets and
+  parallel runs.
+* **SMASH afterburner** needs its own data files; if your config enables SMASH,
+  make sure those are available from the run directory as well.
+* **Never run two instances in the same directory.** MUSIC issues
+  `rm surface*.dat` and writes fixed-name outputs; isolation comes from each run
+  owning its CWD.

--- a/config/jetscape_main.xml
+++ b/config/jetscape_main.xml
@@ -123,6 +123,12 @@
     <initial_Ncoll_list>../examples/test_hydro_files</initial_Ncoll_list>
 
     <MCGlauber>
+      <!--Path to the 3dMCGlauber input file. If omitted (recommended), it is
+          resolved as $XSCAPE_DATA_DIR/mcglauber.input, falling back to
+          ./mcglauber.input when XSCAPE_DATA_DIR is unset. Add an explicit
+          (absolute or relative) path here to override, e.g.
+          <mcglauber_input_file>/abs/path/mcglauber.input</mcglauber_input_file>.
+          Do NOT leave this element empty (an empty element is unsupported).-->
       <!--0: generates full event with binary collisions and strings-->
       <!--1: PythiaISR setup (needs 2 step MCGlauber initialization)-->
       <generateOnlyPositions>0</generateOnlyPositions>
@@ -325,6 +331,11 @@
 
     <Lbt>
       <name> Lbt </name>
+      <!--Directory holding the LBT data tables. If omitted (recommended), it is
+          resolved from the LBT_TABLES_PATH env var, else
+          $XSCAPE_DATA_DIR/LBT-tables, else ./LBT-tables. Add an explicit path
+          here to override, e.g. <LBT_table_path>/abs/path/LBT-tables</LBT_table_path>.
+          Do NOT leave this element empty (an empty element is unsupported).-->
       <Q0> 2.0 </Q0>
       <in_vac> 0 </in_vac>
       <only_leading> 0 </only_leading>

--- a/examples/run_in_workdir.sh
+++ b/examples/run_in_workdir.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Run a single X-SCAPE (runJetscape) instance in its own working directory,
+# reading read-only assets from a shared prefix. This lets many instances run
+# in parallel from ONE build/install tree, instead of one full build directory
+# per concurrent run.
+#
+# The shared asset prefix ("data dir") is the directory that holds EOS/,
+# iSS_tables/, iSS_parameters.dat, LBT-tables/, tables/, eps09/, LHAPDF_Lib/,
+# nucleusConfigs/, data_table/, mcglauber.input, music_input and config/. For an
+# in-build run this is simply the build directory.
+#
+# Read-only assets are located via:
+#   * XSCAPE_DATA_DIR  -> mcglauber.input (resolved in MCGlauberWrapper)
+#   * HYDROPROGRAMPATH -> MUSIC EOS tables (resolved in MUSIC)
+#   * LBT_TABLES_PATH  -> LBT tables (resolved in LBT)
+#   * a per-run copy of jetscape_main.xml with iSS paths rewritten absolute
+#   * symlinks for the few dirs the vendored code still reads CWD-relative
+# Writable per-run state (music_input and all simulation output) lives in the
+# run directory, so concurrent runs never collide.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: run_in_workdir.sh -w RUN_DIR -u USER_XML [-d DATA_DIR] [-b RUNJETSCAPE] [-m MAIN_XML]
+
+  -w RUN_DIR      Per-run working directory (created if missing). REQUIRED.
+  -u USER_XML     User XML config. REQUIRED.
+  -d DATA_DIR     Shared asset prefix. Default: $XSCAPE_DATA_DIR if set,
+                  else the directory containing the runJetscape executable.
+  -b RUNJETSCAPE  Path to the runJetscape executable.
+                  Default: DATA_DIR/runJetscape.
+  -m MAIN_XML     Main XML config. Default: DATA_DIR/config/jetscape_main.xml.
+
+Example (two parallel runs against one build dir):
+  ./run_in_workdir.sh -d /path/to/build -w /tmp/run1 -u /path/to/build/config/jetscape_user_3DGlauber_MUSIC_iSS_SMASH_test.xml &
+  ./run_in_workdir.sh -d /path/to/build -w /tmp/run2 -u /path/to/build/config/jetscape_user_3DGlauber_MUSIC_iSS_SMASH_test.xml &
+  wait
+EOF
+}
+
+# Portable absolute-path helpers (macOS lacks GNU realpath by default).
+abspath_dir() { (cd "$1" >/dev/null 2>&1 && pwd); }
+abspath_file() {
+  local d b
+  d=$(cd "$(dirname "$1")" >/dev/null 2>&1 && pwd) || return 1
+  b=$(basename "$1")
+  printf '%s/%s\n' "$d" "$b"
+}
+
+RUN_DIR=""
+USER_XML=""
+DATA_DIR="${XSCAPE_DATA_DIR:-}"
+RUNJETSCAPE=""
+MAIN_XML=""
+
+while getopts ":w:u:d:b:m:h" opt; do
+  case "$opt" in
+    w) RUN_DIR="$OPTARG" ;;
+    u) USER_XML="$OPTARG" ;;
+    d) DATA_DIR="$OPTARG" ;;
+    b) RUNJETSCAPE="$OPTARG" ;;
+    m) MAIN_XML="$OPTARG" ;;
+    h) usage; exit 0 ;;
+    \?) echo "Unknown option: -$OPTARG" >&2; usage; exit 2 ;;
+    :) echo "Option -$OPTARG requires an argument" >&2; usage; exit 2 ;;
+  esac
+done
+
+[ -n "$RUN_DIR" ] || { echo "ERROR: -w RUN_DIR is required" >&2; usage; exit 2; }
+[ -n "$USER_XML" ] || { echo "ERROR: -u USER_XML is required" >&2; usage; exit 2; }
+
+# Resolve DATA_DIR: explicit/-d/env, else infer from the runJetscape location.
+if [ -z "$DATA_DIR" ] && [ -n "$RUNJETSCAPE" ]; then
+  DATA_DIR=$(dirname "$RUNJETSCAPE")
+fi
+[ -n "$DATA_DIR" ] || { echo "ERROR: data dir unknown; pass -d or set XSCAPE_DATA_DIR" >&2; exit 2; }
+DATA_DIR=$(abspath_dir "$DATA_DIR") || { echo "ERROR: data dir not found: $DATA_DIR" >&2; exit 1; }
+
+[ -n "$RUNJETSCAPE" ] || RUNJETSCAPE="$DATA_DIR/runJetscape"
+[ -x "$RUNJETSCAPE" ] || { echo "ERROR: runJetscape not executable: $RUNJETSCAPE" >&2; exit 1; }
+RUNJETSCAPE=$(abspath_file "$RUNJETSCAPE")
+
+# Default main XML: installed layout (DATA_DIR/config) or in-build layout
+# (config lives at the source root, one level up from the build dir).
+if [ -z "$MAIN_XML" ]; then
+  for cand in "$DATA_DIR/config/jetscape_main.xml" "$DATA_DIR/../config/jetscape_main.xml"; do
+    if [ -f "$cand" ]; then MAIN_XML="$cand"; break; fi
+  done
+fi
+[ -n "$MAIN_XML" ] && [ -f "$MAIN_XML" ] || { echo "ERROR: main XML not found (pass -m); looked in $DATA_DIR/config and $DATA_DIR/../config" >&2; exit 1; }
+MAIN_XML=$(abspath_file "$MAIN_XML")
+
+[ -f "$USER_XML" ] || { echo "ERROR: user XML not found: $USER_XML" >&2; exit 1; }
+USER_XML=$(abspath_file "$USER_XML")
+
+mkdir -p "$RUN_DIR"
+RUN_DIR=$(abspath_dir "$RUN_DIR")
+
+# Per-run main XML: point iSS at absolute asset paths so the run works from any
+# CWD (the shipped config uses ../external_packages/iSS/... relative paths).
+RUN_MAIN_XML="$RUN_DIR/jetscape_main.xml"
+sed -E \
+  -e "s#<iSS_input_file>[^<]*</iSS_input_file>#<iSS_input_file>${DATA_DIR}/iSS_parameters.dat</iSS_input_file>#" \
+  -e "s#<iSS_table_path>[^<]*</iSS_table_path>#<iSS_table_path>${DATA_DIR}/iSS_tables</iSS_table_path>#" \
+  -e "s#<iSS_particle_table_path>[^<]*</iSS_particle_table_path>#<iSS_particle_table_path>${DATA_DIR}/iSS_tables</iSS_particle_table_path>#" \
+  "$MAIN_XML" > "$RUN_MAIN_XML"
+
+# Per-run writable copy of the MUSIC input file (MUSIC rewrites it in place).
+# The shipped config references it CWD-relative as "music_input".
+if [ -f "$DATA_DIR/music_input" ]; then
+  cp -f "$DATA_DIR/music_input" "$RUN_DIR/music_input"
+fi
+
+# Symlink the dirs that the vendored 3dMCGlauber / trento code still reads
+# CWD-relative. These are read-only, so sharing them across runs is safe.
+for asset in tables eps09 LHAPDF_Lib nucleusConfigs data_table; do
+  if [ -e "$DATA_DIR/$asset" ] && [ ! -e "$RUN_DIR/$asset" ]; then
+    ln -s "$DATA_DIR/$asset" "$RUN_DIR/$asset"
+  fi
+done
+
+export XSCAPE_DATA_DIR="$DATA_DIR"
+export HYDROPROGRAMPATH="$DATA_DIR"
+export LBT_TABLES_PATH="$DATA_DIR/LBT-tables"
+
+echo "[run_in_workdir] DATA_DIR   = $DATA_DIR"
+echo "[run_in_workdir] RUN_DIR    = $RUN_DIR"
+echo "[run_in_workdir] runJetscape= $RUNJETSCAPE"
+echo "[run_in_workdir] user XML   = $USER_XML"
+echo "[run_in_workdir] main XML   = $RUN_MAIN_XML"
+
+cd "$RUN_DIR"
+exec "$RUNJETSCAPE" "$USER_XML" "$RUN_MAIN_XML"

--- a/src/framework/JetScapeDataPath.h
+++ b/src/framework/JetScapeDataPath.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) The JETSCAPE Collaboration, 2018
+ *
+ * Modular, task-based framework for simulating all aspects of heavy-ion
+ *collisions
+ *
+ * For the list of contributors see AUTHORS.
+ *
+ * Report issues at https://github.com/JETSCAPE/JETSCAPE/issues
+ *
+ * or via email to bugs.jetscape@gmail.com
+ *
+ * Distributed under the GNU General Public License 3.0 (GPLv3 or later).
+ * See COPYING for details.
+ ******************************************************************************/
+
+#ifndef JETSCAPEDATAPATH_H
+#define JETSCAPEDATAPATH_H
+
+#include <cstdlib>
+#include <string>
+
+namespace Jetscape {
+
+// Root directory holding X-SCAPE read-only data assets (EOS tables, iSS tables,
+// LBT tables, 3dMCGlauber inputs, ...). Honors the XSCAPE_DATA_DIR environment
+// variable so a shared/installed asset tree can be located from an arbitrary
+// per-run working directory. Falls back to "." (current working directory),
+// preserving the historical build-directory behavior.
+inline std::string GetXSCAPEDataDir() {
+  const char *env = std::getenv("XSCAPE_DATA_DIR");
+  if (env != nullptr && env[0] != '\0') {
+    return std::string(env);
+  }
+  return std::string(".");
+}
+
+// Resolve a relative data-asset path against GetXSCAPEDataDir(). An absolute
+// path (leading '/') is returned unchanged.
+inline std::string XSCAPEDataPath(const std::string &relative_path) {
+  if (!relative_path.empty() && relative_path[0] == '/') {
+    return relative_path;
+  }
+  return GetXSCAPEDataDir() + "/" + relative_path;
+}
+
+}  // namespace Jetscape
+
+#endif  // JETSCAPEDATAPATH_H

--- a/src/initialstate/MCGlauberWrapper.cc
+++ b/src/initialstate/MCGlauberWrapper.cc
@@ -23,6 +23,7 @@
 
 #include "JetScapeLogger.h"
 #include "JetScapeSignalManager.h"
+#include "JetScapeDataPath.h"
 #include "MCGlauberWrapper.h"
 
 // Register the module with the base class
@@ -42,8 +43,18 @@ void MCGlauberWrapper::InitTask() {
 
   int argc = 0;
   char *argv[1];
+  // Resolve the 3dMCGlauber input file: an explicit XML path wins; otherwise
+  // fall back to XSCAPE_DATA_DIR/mcglauber.input (i.e. ./mcglauber.input when
+  // the env var is unset), so a shared asset tree can be used from a separate
+  // per-run working directory.
+  std::string mcglauber_input_file =
+      GetXMLElementText({"IS", "MCGlauber", "mcglauber_input_file"}, false);
+  if (mcglauber_input_file.empty()) {
+    mcglauber_input_file = XSCAPEDataPath("mcglauber.input");
+  }
+  JSINFO << "3dMCGlauber input file: " << mcglauber_input_file;
   mc_gen_ = std::shared_ptr<MCGlb::EventGenerator>(
-      new MCGlb::EventGenerator("mcglauber.input", argc, argv, ran_seed));
+      new MCGlb::EventGenerator(mcglauber_input_file, argc, argv, ran_seed));
 
   // overwrite input options
   int para_temp_int;

--- a/src/jet/LBT.cc
+++ b/src/jet/LBT.cc
@@ -17,6 +17,8 @@
 #include "LBT.h"
 #include "JetScapeLogger.h"
 #include "JetScapeXML.h"
+#include "JetScapeDataPath.h"
+#include <cstdlib>
 
 #include "tinyxml2.h"
 #include <string>
@@ -92,8 +94,23 @@ void LBT::InitTask() {
   //...read parameters from LBT.input first, but can be changed in JETSCAPE xml
   // file if any conflict exists
 
-  setParameter(
-      "LBT-tables/LBT.input");  // re-set parameters from input parameter file
+  // Resolve the directory holding the LBT data tables. Priority:
+  //   1. XML element {Eloss, Lbt, LBT_table_path} if set
+  //   2. LBT_TABLES_PATH environment variable
+  //   3. XSCAPE_DATA_DIR/LBT-tables (./LBT-tables when XSCAPE_DATA_DIR is unset)
+  lbt_table_path_ = GetXMLElementText({"Eloss", "Lbt", "LBT_table_path"}, false);
+  if (lbt_table_path_.empty()) {
+    const char *env = std::getenv("LBT_TABLES_PATH");
+    if (env != nullptr && env[0] != '\0') {
+      lbt_table_path_ = env;
+    } else {
+      lbt_table_path_ = XSCAPEDataPath("LBT-tables");
+    }
+  }
+  JSINFO << "LBT tables path: " << lbt_table_path_;
+
+  setParameter(lbt_table_path_ +
+               "/LBT.input");  // re-set parameters from input parameter file
 
   //    if(checkParameter(argc)==0) { // check whether the input parameters are
   //    all correct
@@ -1551,7 +1568,7 @@ void LBT::read_tables() {  // intialize various tables for LBT
   //...read scattering rate
   int it, ie;
   int n = 450;
-  ifstream f1("LBT-tables/ratedata");
+  ifstream f1(lbt_table_path_ + "/ratedata");
   if (!f1.is_open()) {
     cout << "Erro openning date file1!\n";
   } else {
@@ -1566,7 +1583,7 @@ void LBT::read_tables() {  // intialize various tables for LBT
   f1.close();
 
   // duplicate for heavy quark
-  ifstream f11("LBT-tables/ratedata-HQ");
+  ifstream f11(lbt_table_path_ + "/ratedata-HQ");
   if (!f11.is_open()) {
     cout << "Erro openning HQ data file!\n";
   } else {
@@ -1579,11 +1596,11 @@ void LBT::read_tables() {  // intialize various tables for LBT
 
   // read radiation table for heavy quark
   if (KINT0 != 0) {
-    ifstream f12("LBT-tables/dNg_over_dt_cD6.dat");
-    ifstream f13("LBT-tables/dNg_over_dt_qD6.dat");
-    ifstream f14("LBT-tables/dNg_over_dt_gD6.dat");
-    ifstream f15("LBT-tables/dNg_over_dt_qD7.dat");
-    ifstream f16("LBT-tables/dNg_over_dt_gD7.dat");
+    ifstream f12(lbt_table_path_ + "/dNg_over_dt_cD6.dat");
+    ifstream f13(lbt_table_path_ + "/dNg_over_dt_qD6.dat");
+    ifstream f14(lbt_table_path_ + "/dNg_over_dt_gD6.dat");
+    ifstream f15(lbt_table_path_ + "/dNg_over_dt_qD7.dat");
+    ifstream f16(lbt_table_path_ + "/dNg_over_dt_gD7.dat");
     if (!f12.is_open() || !f13.is_open() || !f14.is_open() || !f15.is_open() ||
         !f16.is_open()) {
       cout << "Erro openning HQ radiation table file!\n";
@@ -1642,7 +1659,7 @@ void LBT::read_tables() {  // intialize various tables for LBT
   }
 
   // preparation for HQ 2->2
-  ifstream fileB("LBT-tables/distB.dat");
+  ifstream fileB(lbt_table_path_ + "/distB.dat");
   if (!fileB.is_open()) {
     cout << "Erro openning data file distB.dat!" << endl;
   } else {
@@ -1665,7 +1682,7 @@ void LBT::read_tables() {  // intialize various tables for LBT
   }
   fileB.close();
 
-  ifstream fileF("LBT-tables/distF.dat");
+  ifstream fileF(lbt_table_path_ + "/distF.dat");
   if (!fileF.is_open()) {
     cout << "Erro openning data file distF.dat!" << endl;
   } else {

--- a/src/jet/LBT.h
+++ b/src/jet/LBT.h
@@ -400,6 +400,8 @@ class LBT
   double ModificationCorr;
   double ModificationFactor;
 
+  std::string lbt_table_path_;  // directory holding the LBT data tables
+
   //  extern "C" {
   //      void read_ccnu_(char *dataFN_in, int len1);
   //      void hydroinfoccnu_(double *Ct, double *Cx, double *Cy, double *Cz,


### PR DESCRIPTION
Add a single framework-wide data-root knob (XSCAPE_DATA_DIR, helper in JetScapeDataPath.h) so read-only assets can be located from a shared prefix, and make the two remaining CWD-hard-coded lookups configurable:
 - 3dMCGlauber mcglauber.input (MCGlauberWrapper + optional XML knob)
 - LBT data tables (LBT.cc/LBT.h + LBT_TABLES_PATH env / XML knob)

Add examples/run_in_workdir.sh to run each instance in its own working directory (per-run main XML with absolute iSS paths, per-run writable music_input copy, symlinked read-only dirs, env vars set), so many runJetscape instances can run concurrently against one build/install tree without separate build directories. Defaults reduce to the historical build-dir behavior when XSCAPE_DATA_DIR is unset.

Docs: README_Launcher.md (usage) and PlanInstall.md (full install roadmap).